### PR TITLE
chore: add CI workflow, AGENTS.md, fix formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MIX_ENV: test
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
+          restore-keys: deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-
+
+      - run: mix deps.get
+      - run: mix format --check-formatted
+      - run: mix compile
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
+          restore-keys: deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-
+
+      - run: mix deps.get
+      - run: mix test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.4.1
+elixir 1.19.5-otp-28

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# minga-org — Agent & Developer Guide
+
+## Project Overview
+
+minga-org is an extension for the [Minga editor](https://github.com/jsmestad/minga) that adds org-mode support: syntax highlighting, heading folding, TODO cycling, checkbox toggling, list continuation, inline markup, and org-specific keybindings.
+
+The extension compiles and runs standalone for testing but depends on `Minga.*` modules at runtime when loaded into the editor. Compilation warnings about missing `Minga.*` modules are expected.
+
+## Tech Stack
+
+- **Elixir 1.19** / OTP 28
+- **ExUnit** for testing
+- **tree-sitter-org** vendored grammar (compiled at runtime by Minga's `TreeSitter.register_grammar/3`)
+- Pinned versions in `.tool-versions`
+
+## Project Structure
+
+```
+lib/
+  minga_org.ex                # Root module, extension callbacks (init, name, version)
+  minga_org/
+    buffer.ex                 # Thin wrapper around Minga.Buffer.Server
+    checkbox.ex               # Checkbox toggling ([ ] <-> [x])
+    commands.ex               # Command registration with Minga.Command.Registry
+    folding.ex                # Heading fold/unfold with TAB/S-TAB cycling
+    grammar.ex                # Grammar compilation and filetype registration
+    heading.ex                # Heading promote/demote/move
+    keybindings.ex            # SPC m keybinding registration
+    todo.ex                   # TODO keyword cycling
+
+queries/
+  org/
+    highlights.scm            # Tree-sitter highlight query for org syntax
+
+vendor/
+  tree-sitter-org/
+    src/                      # Vendored grammar C sources (parser.c, scanner.c)
+
+test/                         # Mirrors lib/ structure
+```
+
+## Epic Tracker
+
+All org-mode work is tracked under [#1 (Epic: Org-mode support)](https://github.com/jsmestad/minga-org/issues/1) with child tickets #2 through #13.
+
+## Git Branching
+
+**`main` is protected.** All changes go through feature branches and pull requests. Never commit directly to main.
+
+- Always create a feature branch before making changes. Use descriptive names: `feat/smart-list-continuation`, `fix/checkbox-toggle-indent`, `chore/ci-setup`.
+- Check your current branch before starting work: `git branch --show-current`.
+- Push your branch and open a PR when the work is ready. CI must pass before merging.
+
+## Coding Standards
+
+### Elixir Types (mandatory)
+
+Elixir 1.19's set-theoretic type system catches real bugs at compile time. Help it by being explicit:
+
+- **`@spec`** on every public function, no exceptions
+- **`@type` / `@typep`** for all custom types in every module
+- **`@enforce_keys`** on structs for required fields
+- **Guards** in function heads where they aid type inference
+- **Pattern matching** over `if/cond`. Use multi-clause functions with pattern matching and guards instead of `cond` blocks
+- **No `cond` blocks.** Extract a private helper with multiple `defp` clauses instead. `cond` defeats BEAM JIT optimizations and hides control flow
+- **Bulk text operations.** When inserting or replacing multi-character text in a buffer, always use `Buffer.apply_text_edit/6` or `Buffer.apply_text_edits/2`. Never decompose a string into graphemes and loop
+- `mix compile` must pass clean (warnings about missing `Minga.*` modules are expected and acceptable)
+
+### Common Elixir Footguns
+
+- **Lists don't support index access.** `mylist[0]` doesn't work. Use `Enum.at(mylist, 0)`, `hd/1`, or pattern matching.
+- **Bind the result of block expressions.** Variables can't be rebound inside `if`/`case`/`with` and leak out. Always bind: `state = if condition, do: new_state, else: state`.
+- **Never nest multiple modules in one file.** One `defmodule` per `.ex` file.
+- **Don't use `String.to_atom/1` on user input.** Atoms are never garbage collected.
+- **Predicate functions end in `?`, not `is_`.** Reserve `is_` for guard-compatible functions only.
+- **Don't use map access syntax on structs.** `my_struct[:field]` doesn't work. Use `my_struct.field` or pattern match.
+
+### Testing
+
+- Test files mirror `lib/` structure: `lib/minga_org/checkbox.ex` -> `test/minga_org/checkbox_test.exs`
+- **Descriptive names**: `"checks an unchecked checkbox"` not `"test toggle/1"`
+- **Edge cases always tested**: empty state, boundaries, unicode, nested structures
+- **Pure-logic tests preferred.** Since `Minga.*` modules aren't available in the test environment, test the pure logic functions (text parsing, transformation, pattern matching) directly. Functions that call `Buffer.*` are tested via integration tests in the main Minga repo.
+- **Every new feature must include tests.** If a module has pure logic that can be tested standalone, it must have tests before merging.
+
+Running tests:
+
+```bash
+mix test                              # Full suite
+mix test test/minga_org/checkbox_test.exs  # Single file
+mix test test/minga_org/checkbox_test.exs:10  # Single test (line number)
+mix test --failed                     # Re-run only failures
+```
+
+### Commit Messages
+
+```
+type(scope): short description
+
+Longer body if needed.
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+Scopes: `checkbox`, `todo`, `heading`, `folding`, `list`, `markup`, `grammar`, `keybindings`
+
+Examples:
+- `feat(list): smart continuation on Enter for unordered lists`
+- `fix(checkbox): preserve indentation when toggling nested items`
+- `test(todo): add edge cases for custom keyword sequences`
+- `chore(ci): add GitHub Actions workflow`
+
+## Build It Right or Don't Build It
+
+Never scope foundational infrastructure to a "V1" that deliberately skips known requirements. If a data structure needs to handle deeply nested org trees, build it with the right algorithm from the start. If a system needs to handle all org list types, don't ship only unordered and plan to "add ordered later."
+
+This applies to internal infrastructure like parsers, text manipulation helpers, and data structures. It does not apply to user-facing features, where shipping a subset (e.g., checkbox toggle before smart continuation) is a legitimate scoping choice.
+
+## Extension Architecture
+
+minga-org follows the Minga extension contract:
+
+1. **`MingaOrg.init/1`** is the entry point. It registers the grammar, keybindings, and commands.
+2. **Grammar registration** (`MingaOrg.Grammar`) compiles the vendored tree-sitter-org sources and registers the `.org` filetype.
+3. **Command registration** (`MingaOrg.Commands`) registers all org commands with `Minga.Command.Registry`.
+4. **Keybinding registration** (`MingaOrg.Keybindings`) binds keys under `SPC m`, scoped to the `:org` filetype.
+5. **`MingaOrg.Buffer`** wraps `Minga.Buffer.Server` calls. All buffer interaction goes through this module so if the Minga API changes, only one file needs updating.
+
+When adding a new feature:
+1. Create a new module in `lib/minga_org/` with the pure logic
+2. Register its command(s) in `MingaOrg.Commands`
+3. Add keybinding(s) in `MingaOrg.Keybindings`
+4. Write tests for the pure logic in `test/minga_org/`

--- a/lib/minga_org/buffer.ex
+++ b/lib/minga_org/buffer.ex
@@ -35,7 +35,14 @@ defmodule MingaOrg.Buffer do
   end
 
   @doc "Replaces a range of text with new text."
-  @spec apply_text_edit(pid(), non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()) :: :ok
+  @spec apply_text_edit(
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t()
+        ) :: :ok
   def apply_text_edit(buf, start_line, start_col, end_line, end_col, new_text) do
     Minga.Buffer.Server.apply_text_edit(buf, start_line, start_col, end_line, end_col, new_text)
   end

--- a/lib/minga_org/folding.ex
+++ b/lib/minga_org/folding.ex
@@ -81,7 +81,9 @@ defmodule MingaOrg.Folding do
 
   # ── Private: heading parsing ───────────────────────────────────────────────
 
-  @spec collect_headings(pid(), non_neg_integer(), non_neg_integer(), [{non_neg_integer(), pos_integer()}]) ::
+  @spec collect_headings(pid(), non_neg_integer(), non_neg_integer(), [
+          {non_neg_integer(), pos_integer()}
+        ]) ::
           [{non_neg_integer(), pos_integer()}]
   defp collect_headings(_buf, line, total, acc) when line >= total do
     Enum.reverse(acc)
@@ -117,7 +119,12 @@ defmodule MingaOrg.Folding do
     end)
   end
 
-  @spec find_heading_end([{non_neg_integer(), pos_integer()}], non_neg_integer(), pos_integer(), non_neg_integer()) ::
+  @spec find_heading_end(
+          [{non_neg_integer(), pos_integer()}],
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) ::
           non_neg_integer()
   defp find_heading_end(headings, idx, level, total) do
     rest = Enum.drop(headings, idx + 1)

--- a/lib/minga_org/heading.ex
+++ b/lib/minga_org/heading.ex
@@ -106,7 +106,15 @@ defmodule MingaOrg.Heading do
     end
   end
 
-  @spec do_swap(map(), pid(), :up | :down, non_neg_integer(), non_neg_integer(), pos_integer(), non_neg_integer()) :: map()
+  @spec do_swap(
+          map(),
+          pid(),
+          :up | :down,
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) :: map()
   defp do_swap(state, buf, :up, line_num, subtree_end, level, _total) do
     case find_prev_sibling(buf, line_num, level) do
       nil ->
@@ -146,12 +154,14 @@ defmodule MingaOrg.Heading do
     end
   end
 
-  @spec find_subtree_end(pid(), non_neg_integer(), pos_integer(), non_neg_integer()) :: non_neg_integer()
+  @spec find_subtree_end(pid(), non_neg_integer(), pos_integer(), non_neg_integer()) ::
+          non_neg_integer()
   defp find_subtree_end(buf, start_line, level, total) do
     find_subtree_end_loop(buf, start_line + 1, level, total)
   end
 
-  @spec find_subtree_end_loop(pid(), non_neg_integer(), pos_integer(), non_neg_integer()) :: non_neg_integer()
+  @spec find_subtree_end_loop(pid(), non_neg_integer(), pos_integer(), non_neg_integer()) ::
+          non_neg_integer()
   defp find_subtree_end_loop(buf, current, level, total) when current < total do
     case Buffer.line_at(buf, current) do
       {:ok, line} ->
@@ -191,7 +201,13 @@ defmodule MingaOrg.Heading do
     end
   end
 
-  @spec swap_ranges(pid(), non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: :ok
+  @spec swap_ranges(
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: :ok
   defp swap_ranges(buf, a_start, a_end, b_start, b_end) do
     a_lines = read_lines(buf, a_start, a_end)
     b_lines = read_lines(buf, b_start, b_end)

--- a/lib/minga_org/todo.ex
+++ b/lib/minga_org/todo.ex
@@ -72,7 +72,8 @@ defmodule MingaOrg.Todo do
 
   Returns `{:ok, stars, keyword_or_nil, rest_of_text}` or `:not_heading`.
   """
-  @spec parse_heading(String.t()) :: {:ok, String.t(), String.t() | nil, String.t()} | :not_heading
+  @spec parse_heading(String.t()) ::
+          {:ok, String.t(), String.t() | nil, String.t()} | :not_heading
   def parse_heading(line) do
     case Regex.run(~r/^(\*+) (.*)$/, line) do
       [_match, stars, rest] ->

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule MingaOrg.MixProject do
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      aliases: aliases(),
       description: "Org-mode support for the Minga editor",
       package: package(),
       source_url: @source_url,
@@ -44,6 +45,12 @@ defmodule MingaOrg.MixProject do
         "README.md",
         "LICENSE"
       ]
+    ]
+  end
+
+  defp aliases do
+    [
+      lint: ["format --check-formatted", "compile"]
     ]
   end
 

--- a/test/minga_org/todo_test.exs
+++ b/test/minga_org/todo_test.exs
@@ -48,7 +48,8 @@ defmodule MingaOrg.TodoTest do
     end
 
     test "cycles TODO to DONE" do
-      assert "* DONE Buy groceries" = Todo.cycle_keyword("* TODO Buy groceries", @default_keywords)
+      assert "* DONE Buy groceries" =
+               Todo.cycle_keyword("* TODO Buy groceries", @default_keywords)
     end
 
     test "removes DONE (cycles to none)" do


### PR DESCRIPTION
## What

Sets up the project infrastructure for ongoing development:

- **GitHub Actions CI** runs on every PR and push to main with two jobs: lint (format check + compile) and test (full ExUnit suite)
- **AGENTS.md** documents coding standards, testing guidelines, git branching rules, commit message conventions, and extension architecture. Borrowed from the main Minga repo, trimmed to Elixir-only content relevant to this extension.
- **.tool-versions** pins Erlang 28.4.1 / Elixir 1.19.5 to match the main repo
- **mix lint alias** added so the commit-gate extension works
- **mix format** applied to existing files that had long `@spec` lines exceeding the formatter line length

## Why

Needed before we start building the remaining org-mode features (#5 through #13). CI catches regressions on PRs, AGENTS.md keeps agent sessions consistent, and the lint alias unblocks the commit-gate workflow.