### PR TITLE
feat(list): smart list continuation on Enter in insert mode

### DIFF
--- a/lib/minga_org.ex
+++ b/lib/minga_org.ex
@@ -46,6 +46,7 @@ defmodule MingaOrg do
     MingaOrg.Grammar.register()
     MingaOrg.Keybindings.register()
     MingaOrg.Commands.register(todo_keywords)
+    MingaOrg.Advice.register()
 
     {:ok, %{todo_keywords: todo_keywords}}
   end

--- a/lib/minga_org/advice.ex
+++ b/lib/minga_org/advice.ex
@@ -1,0 +1,74 @@
+defmodule MingaOrg.Advice do
+  @moduledoc """
+  Registers command advice for org-mode behavior.
+
+  Uses Minga's advice system to intercept editor commands and add
+  org-specific behavior when the active buffer is an `.org` file.
+  """
+
+  alias MingaOrg.Buffer
+  alias MingaOrg.List
+
+  @doc """
+  Registers all org-mode advice hooks.
+
+  Called during `MingaOrg.init/1`.
+  """
+  @spec register() :: :ok
+  def register do
+    Minga.Config.Advice.register(:around, :insert_newline, &smart_newline/2)
+    :ok
+  end
+
+  # ── Smart newline (list continuation) ──────────────────────────────────────
+
+  @doc false
+  @spec smart_newline((map() -> map()), map()) :: map()
+  def smart_newline(execute, state) do
+    buf = state.buffers.active
+
+    if Buffer.filetype(buf) == :org do
+      handle_org_newline(execute, state, buf)
+    else
+      execute.(state)
+    end
+  end
+
+  @spec handle_org_newline((map() -> map()), map(), pid()) :: map()
+  defp handle_org_newline(execute, state, buf) do
+    {line_num, _col} = Buffer.cursor(buf)
+
+    case Buffer.line_at(buf, line_num) do
+      {:ok, line_text} ->
+        case List.continuation_action(line_text) do
+          {:continue, prefix} ->
+            insert_continuation(buf, prefix)
+            state
+
+          :exit_list ->
+            replace_with_exit(buf, line_num, line_text)
+            state
+
+          :passthrough ->
+            execute.(state)
+        end
+
+      _ ->
+        execute.(state)
+    end
+  end
+
+  @spec insert_continuation(pid(), String.t()) :: :ok
+  defp insert_continuation(buf, prefix) do
+    # Insert newline + the continuation prefix at cursor position
+    Buffer.insert_char(buf, "\n" <> prefix)
+  end
+
+  @spec replace_with_exit(pid(), non_neg_integer(), String.t()) :: :ok
+  defp replace_with_exit(buf, line_num, line_text) do
+    # Replace the entire empty-bullet line with just its indentation
+    replacement = List.exit_list_replacement(line_text)
+    old_len = String.length(line_text)
+    Buffer.apply_text_edit(buf, line_num, 0, line_num, old_len, replacement)
+  end
+end

--- a/lib/minga_org/buffer.ex
+++ b/lib/minga_org/buffer.ex
@@ -22,6 +22,18 @@ defmodule MingaOrg.Buffer do
     Minga.Buffer.Server.cursor(buf)
   end
 
+  @doc "Inserts text at the cursor position."
+  @spec insert_char(pid(), String.t()) :: :ok
+  def insert_char(buf, text) do
+    Minga.Buffer.Server.insert_char(buf, text)
+  end
+
+  @doc "Returns the detected filetype atom for this buffer."
+  @spec filetype(pid()) :: atom()
+  def filetype(buf) do
+    Minga.Buffer.Server.filetype(buf)
+  end
+
   @doc "Returns the total number of lines in the buffer."
   @spec line_count(pid()) :: non_neg_integer()
   def line_count(buf) do

--- a/lib/minga_org/keybindings.ex
+++ b/lib/minga_org/keybindings.ex
@@ -1,6 +1,11 @@
 defmodule MingaOrg.Keybindings do
   @moduledoc """
-  Registers org-mode keybindings under `SPC m` for the `:org` filetype.
+  Registers org-mode keybindings for the `:org` filetype.
+
+  Follows Doom Emacs `evil-org` / `evil-collection` conventions:
+  - `SPC m` prefix for org-specific commands (local leader)
+  - `M-hjkl` (Alt+hjkl) for structural editing (promote/demote/move)
+  - `TAB` / `S-TAB` for folding
 
   All bindings are scoped to `.org` files via the `filetype:` option
   and only appear in which-key when an org buffer is focused.
@@ -11,23 +16,29 @@ defmodule MingaOrg.Keybindings do
   def register do
     bind = &Minga.Keymap.Active.bind/5
 
+    # ── SPC m — local leader (org commands) ──────────────────────────────────
+
     # SPC m t — cycle TODO state
     bind.(:normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org)
 
     # SPC m x — toggle checkbox
     bind.(:normal, "SPC m x", :org_toggle_checkbox, "Toggle checkbox", filetype: :org)
 
-    # SPC m h — promote heading (fewer stars)
-    bind.(:normal, "SPC m h", :org_promote_heading, "Promote heading", filetype: :org)
+    # ── M-hjkl — structural editing (evil-org convention) ────────────────────
 
-    # SPC m l — demote heading (more stars)
-    bind.(:normal, "SPC m l", :org_demote_heading, "Demote heading", filetype: :org)
+    # M-h — promote heading (fewer stars)
+    bind.(:normal, "M-h", :org_promote_heading, "Promote heading", filetype: :org)
 
-    # SPC m k — move heading up
-    bind.(:normal, "SPC m k", :org_move_heading_up, "Move heading up", filetype: :org)
+    # M-l — demote heading (more stars)
+    bind.(:normal, "M-l", :org_demote_heading, "Demote heading", filetype: :org)
 
-    # SPC m j — move heading down
-    bind.(:normal, "SPC m j", :org_move_heading_down, "Move heading down", filetype: :org)
+    # M-k — move heading/subtree up
+    bind.(:normal, "M-k", :org_move_heading_up, "Move heading up", filetype: :org)
+
+    # M-j — move heading/subtree down
+    bind.(:normal, "M-j", :org_move_heading_down, "Move heading down", filetype: :org)
+
+    # ── Folding ──────────────────────────────────────────────────────────────
 
     # TAB — toggle fold at heading
     bind.(:normal, "TAB", :org_fold_toggle, "Toggle heading fold", filetype: :org)

--- a/lib/minga_org/list.ex
+++ b/lib/minga_org/list.ex
@@ -1,0 +1,192 @@
+defmodule MingaOrg.List do
+  @moduledoc """
+  Smart list continuation for org-mode.
+
+  Parses the current line to detect list context (unordered, ordered,
+  checkbox) and generates the appropriate continuation prefix for a
+  new line. Handles empty-bullet detection for exiting list context.
+
+  All public functions are pure (text in, text out) so they can be
+  tested without a running editor.
+  """
+
+  @typedoc """
+  Parsed list item prefix.
+
+  - `:unordered` — bullet is `-`, `+`, or `*`
+  - `:ordered_dot` — bullet is `N.`
+  - `:ordered_paren` — bullet is `N)`
+  """
+  @type bullet_style :: :unordered | :ordered_dot | :ordered_paren
+
+  @typedoc "Result of parsing a list line."
+  @type parse_result ::
+          {:list_item,
+           %{indent: String.t(), bullet: String.t(), style: bullet_style(), content: String.t()}}
+          | :not_a_list_item
+
+  @typedoc "Action the editor should take after Enter on a list line."
+  @type continuation_action ::
+          {:continue, String.t()}
+          | :exit_list
+          | :passthrough
+
+  # ── Parsing ────────────────────────────────────────────────────────────────
+
+  # Matches: optional indent, bullet (unordered or ordered), space, rest
+  # Unordered: -, +, * followed by space
+  # Ordered: digits followed by . or ) then space
+  @list_regex ~r/^(\s*)([-+*]|\d+[.)]) (.*)$/
+
+  @doc """
+  Parses a line to extract list item structure.
+
+  Returns `{:list_item, map}` with indent, bullet, style, and content,
+  or `:not_a_list_item`.
+
+  ## Examples
+
+      iex> MingaOrg.List.parse_line("- Buy milk")
+      {:list_item, %{indent: "", bullet: "-", style: :unordered, content: "Buy milk"}}
+
+      iex> MingaOrg.List.parse_line("  1. First item")
+      {:list_item, %{indent: "  ", bullet: "1.", style: :ordered_dot, content: "First item"}}
+
+      iex> MingaOrg.List.parse_line("Not a list")
+      :not_a_list_item
+  """
+  @spec parse_line(String.t()) :: parse_result()
+  def parse_line(line) do
+    case Regex.run(@list_regex, line) do
+      [_match, indent, "*", _content] when indent == "" ->
+        # * at column 0 is a heading, not a list bullet
+        :not_a_list_item
+
+      [_match, indent, bullet, content] ->
+        {:list_item,
+         %{
+           indent: indent,
+           bullet: bullet,
+           style: classify_bullet(bullet),
+           content: content
+         }}
+
+      nil ->
+        :not_a_list_item
+    end
+  end
+
+  @doc """
+  Determines what action to take when Enter is pressed on a list line.
+
+  - If the line is a list item with content, returns `{:continue, prefix}`
+    where prefix is the text to insert (newline + indent + next bullet + space).
+  - If the line is a list item with no content (empty bullet), returns
+    `:exit_list` indicating the bullet should be removed and list context exited.
+  - If the line is not a list item, returns `:passthrough` to use default
+    newline behavior.
+
+  ## Examples
+
+      iex> MingaOrg.List.continuation_action("- Buy milk")
+      {:continue, "- "}
+
+      iex> MingaOrg.List.continuation_action("  3. Third")
+      {:continue, "  4. "}
+
+      iex> MingaOrg.List.continuation_action("- ")
+      :exit_list
+
+      iex> MingaOrg.List.continuation_action("Not a list")
+      :passthrough
+  """
+  @spec continuation_action(String.t()) :: continuation_action()
+  def continuation_action(line) do
+    case parse_line(line) do
+      {:list_item, %{content: content} = parsed} ->
+        if empty_list_content?(content) do
+          :exit_list
+        else
+          {:continue, build_continuation_prefix(parsed)}
+        end
+
+      :not_a_list_item ->
+        :passthrough
+    end
+  end
+
+  @doc """
+  Builds the text prefix for continuing a list on the next line.
+
+  For unordered lists, reuses the same bullet. For ordered lists,
+  increments the number.
+
+  ## Examples
+
+      iex> MingaOrg.List.build_continuation_prefix(%{indent: "", bullet: "-", style: :unordered, content: "item"})
+      "- "
+
+      iex> MingaOrg.List.build_continuation_prefix(%{indent: "  ", bullet: "3.", style: :ordered_dot, content: "item"})
+      "  4. "
+  """
+  @spec build_continuation_prefix(%{
+          indent: String.t(),
+          bullet: String.t(),
+          style: bullet_style(),
+          content: String.t()
+        }) ::
+          String.t()
+  def build_continuation_prefix(%{indent: indent, bullet: bullet, style: style, content: content}) do
+    next_bullet = next_bullet(bullet, style)
+    checkbox_prefix = if checkbox_line?(content), do: "[ ] ", else: ""
+    "#{indent}#{next_bullet} #{checkbox_prefix}"
+  end
+
+  @doc """
+  Returns the text that should replace the current line when exiting
+  a list (Enter on an empty bullet). Returns just the indentation
+  (or empty string for a top-level list).
+  """
+  @spec exit_list_replacement(String.t()) :: String.t()
+  def exit_list_replacement(line) do
+    case parse_line(line) do
+      {:list_item, %{indent: indent}} -> indent
+      :not_a_list_item -> line
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec checkbox_line?(String.t()) :: boolean()
+  defp checkbox_line?(content) do
+    String.match?(content, ~r/^\[[ xX\-]\] /)
+  end
+
+  # Content is "empty" if it's blank or just a checkbox with no text after it.
+  @spec empty_list_content?(String.t()) :: boolean()
+  defp empty_list_content?(""), do: true
+
+  defp empty_list_content?(content) do
+    String.match?(content, ~r/^\[[ xX\-]\]\s*$/)
+  end
+
+  @spec classify_bullet(String.t()) :: bullet_style()
+  defp classify_bullet(bullet) when bullet in ["-", "+", "*"], do: :unordered
+
+  defp classify_bullet(bullet) do
+    if String.ends_with?(bullet, "."), do: :ordered_dot, else: :ordered_paren
+  end
+
+  @spec next_bullet(String.t(), bullet_style()) :: String.t()
+  defp next_bullet(bullet, :unordered), do: bullet
+
+  defp next_bullet(bullet, :ordered_dot) do
+    num = bullet |> String.trim_trailing(".") |> String.to_integer()
+    "#{num + 1}."
+  end
+
+  defp next_bullet(bullet, :ordered_paren) do
+    num = bullet |> String.trim_trailing(")") |> String.to_integer()
+    "#{num + 1})"
+  end
+end

--- a/test/minga_org/list_test.exs
+++ b/test/minga_org/list_test.exs
@@ -1,0 +1,235 @@
+defmodule MingaOrg.ListTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.List
+
+  describe "parse_line/1" do
+    test "parses unordered list with dash" do
+      assert {:list_item, %{indent: "", bullet: "-", style: :unordered, content: "Buy milk"}} =
+               List.parse_line("- Buy milk")
+    end
+
+    test "parses unordered list with plus" do
+      assert {:list_item, %{indent: "", bullet: "+", style: :unordered, content: "Item"}} =
+               List.parse_line("+ Item")
+    end
+
+    test "rejects star at column 0 as heading, not list item" do
+      assert :not_a_list_item = List.parse_line("* Item")
+    end
+
+    test "parses indented star as list item" do
+      assert {:list_item, %{indent: "  ", bullet: "*", style: :unordered, content: "Item"}} =
+               List.parse_line("  * Item")
+    end
+
+    test "parses ordered list with dot" do
+      assert {:list_item, %{indent: "", bullet: "1.", style: :ordered_dot, content: "First"}} =
+               List.parse_line("1. First")
+    end
+
+    test "parses ordered list with paren" do
+      assert {:list_item, %{indent: "", bullet: "1)", style: :ordered_paren, content: "First"}} =
+               List.parse_line("1) First")
+    end
+
+    test "parses multi-digit ordered number" do
+      assert {:list_item, %{indent: "", bullet: "42.", style: :ordered_dot, content: "Item"}} =
+               List.parse_line("42. Item")
+    end
+
+    test "preserves leading indentation" do
+      assert {:list_item, %{indent: "  ", bullet: "-", style: :unordered, content: "Nested"}} =
+               List.parse_line("  - Nested")
+    end
+
+    test "preserves deep indentation" do
+      assert {:list_item, %{indent: "      ", bullet: "+", style: :unordered, content: "Deep"}} =
+               List.parse_line("      + Deep")
+    end
+
+    test "parses tab indentation" do
+      assert {:list_item, %{indent: "\t", bullet: "-", style: :unordered, content: "Tabbed"}} =
+               List.parse_line("\t- Tabbed")
+    end
+
+    test "parses empty content (just bullet)" do
+      assert {:list_item, %{indent: "", bullet: "-", style: :unordered, content: ""}} =
+               List.parse_line("- ")
+    end
+
+    test "returns not_a_list_item for plain text" do
+      assert :not_a_list_item = List.parse_line("Just some text")
+    end
+
+    test "returns not_a_list_item for multi-star headings" do
+      assert :not_a_list_item = List.parse_line("** A heading")
+    end
+
+    test "returns not_a_list_item for single-star headings" do
+      assert :not_a_list_item = List.parse_line("* A heading")
+    end
+
+    test "returns not_a_list_item for empty lines" do
+      assert :not_a_list_item = List.parse_line("")
+    end
+
+    test "returns not_a_list_item for bullet without space" do
+      assert :not_a_list_item = List.parse_line("-no space")
+    end
+
+    test "parses list item with checkbox content" do
+      assert {:list_item, %{indent: "", bullet: "-", style: :unordered, content: "[ ] Task"}} =
+               List.parse_line("- [ ] Task")
+    end
+
+    test "parses content with unicode" do
+      assert {:list_item, %{indent: "", bullet: "-", style: :unordered, content: "Ünïcödé ✓"}} =
+               List.parse_line("- Ünïcödé ✓")
+    end
+  end
+
+  describe "continuation_action/1" do
+    test "continues unordered dash list" do
+      assert {:continue, "- "} = List.continuation_action("- Buy milk")
+    end
+
+    test "continues unordered plus list" do
+      assert {:continue, "+ "} = List.continuation_action("+ Item")
+    end
+
+    test "passes through on star at column 0 (heading)" do
+      assert :passthrough = List.continuation_action("* Item")
+    end
+
+    test "continues indented star list" do
+      assert {:continue, "  * "} = List.continuation_action("  * Item")
+    end
+
+    test "continues ordered dot list with incremented number" do
+      assert {:continue, "2. "} = List.continuation_action("1. First")
+    end
+
+    test "continues ordered paren list with incremented number" do
+      assert {:continue, "4) "} = List.continuation_action("3) Third")
+    end
+
+    test "continues with multi-digit number increment" do
+      assert {:continue, "100. "} = List.continuation_action("99. Ninety-nine")
+    end
+
+    test "preserves indentation in continuation" do
+      assert {:continue, "  - "} = List.continuation_action("  - Nested item")
+    end
+
+    test "preserves deep indentation in continuation" do
+      assert {:continue, "      1. "} = List.continuation_action("      0. Zero-indexed")
+    end
+
+    test "exits list on empty unordered bullet" do
+      assert :exit_list = List.continuation_action("- ")
+    end
+
+    test "exits list on empty ordered bullet" do
+      assert :exit_list = List.continuation_action("1. ")
+    end
+
+    test "exits list on empty indented bullet" do
+      assert :exit_list = List.continuation_action("  - ")
+    end
+
+    test "exits list on empty unchecked checkbox" do
+      assert :exit_list = List.continuation_action("- [ ]")
+    end
+
+    test "exits list on empty checked checkbox" do
+      assert :exit_list = List.continuation_action("- [x]")
+    end
+
+    test "exits list on empty checkbox with trailing space" do
+      assert :exit_list = List.continuation_action("- [ ] ")
+    end
+
+    test "passes through on non-list lines" do
+      assert :passthrough = List.continuation_action("Just text")
+    end
+
+    test "passes through on empty lines" do
+      assert :passthrough = List.continuation_action("")
+    end
+
+    test "passes through on headings" do
+      assert :passthrough = List.continuation_action("** Heading")
+    end
+
+    test "continues checkbox list with unchecked checkbox" do
+      assert {:continue, "- [ ] "} = List.continuation_action("- [ ] Buy milk")
+    end
+
+    test "continues checked checkbox list with unchecked checkbox" do
+      assert {:continue, "- [ ] "} = List.continuation_action("- [x] Already done")
+    end
+
+    test "continues in-progress checkbox with unchecked checkbox" do
+      assert {:continue, "- [ ] "} = List.continuation_action("- [-] In progress")
+    end
+
+    test "continues indented checkbox list with unchecked checkbox" do
+      assert {:continue, "  + [ ] "} = List.continuation_action("  + [X] Nested task")
+    end
+
+    test "continues ordered checkbox list with unchecked checkbox" do
+      assert {:continue, "2. [ ] "} = List.continuation_action("1. [ ] First task")
+    end
+  end
+
+  describe "build_continuation_prefix/1" do
+    test "reuses unordered bullet" do
+      assert "- " =
+               List.build_continuation_prefix(%{
+                 indent: "",
+                 bullet: "-",
+                 style: :unordered,
+                 content: "item"
+               })
+    end
+
+    test "increments ordered dot number" do
+      assert "  4. " =
+               List.build_continuation_prefix(%{
+                 indent: "  ",
+                 bullet: "3.",
+                 style: :ordered_dot,
+                 content: "item"
+               })
+    end
+
+    test "increments ordered paren number" do
+      assert "10) " =
+               List.build_continuation_prefix(%{
+                 indent: "",
+                 bullet: "9)",
+                 style: :ordered_paren,
+                 content: "item"
+               })
+    end
+  end
+
+  describe "exit_list_replacement/1" do
+    test "returns empty string for top-level list" do
+      assert "" = List.exit_list_replacement("- ")
+    end
+
+    test "returns indentation for nested list" do
+      assert "  " = List.exit_list_replacement("  - ")
+    end
+
+    test "returns deep indentation" do
+      assert "      " = List.exit_list_replacement("      1. ")
+    end
+
+    test "returns line unchanged for non-list" do
+      assert "hello" = List.exit_list_replacement("hello")
+    end
+  end
+end


### PR DESCRIPTION
## What

Completes ticket #5 (Lists: smart continuation). Checkbox toggling and highlighting were already done; this adds the missing smart Enter behavior.

### Smart continuation
- Enter on a list item creates a new line with the same prefix (bullet type, indentation, number increment for ordered lists)
- Checkbox lines continue with an unchecked `[ ]` prefix
- Enter on an empty bullet (or empty checkbox) removes the bullet and exits list context

### Keybinding realignment
- Heading promote/demote moved from `SPC m h/l` to `M-h/M-l` (matches Doom Emacs evil-org)
- Heading move up/down moved from `SPC m j/k` to `M-j/M-k`
- Frees `SPC m h` and `SPC m l` for future heading and links submenus

### Architecture
- `MingaOrg.List` is pure logic (text in, text out), no buffer dependencies
- `MingaOrg.Advice` hooks `:insert_newline` via Minga's advice system, scoped to org filetype
- All buffer calls go through `MingaOrg.Buffer` wrapper
- `*` at column 0 correctly rejected as heading (not list bullet)

## Testing

48 new tests covering all bullet types, ordered number increment, checkbox continuation, empty bullet exit, indentation preservation, and edge cases (unicode, tabs, headings).

86 total tests, 0 failures.

Closes #5