### PR TITLE
feat(markup): inline markup parser and decoration applicator

### DIFF
--- a/lib/minga_org/advice.ex
+++ b/lib/minga_org/advice.ex
@@ -8,6 +8,7 @@ defmodule MingaOrg.Advice do
 
   alias MingaOrg.Buffer
   alias MingaOrg.List
+  alias MingaOrg.Markup
 
   @doc """
   Registers all org-mode advice hooks.
@@ -17,6 +18,14 @@ defmodule MingaOrg.Advice do
   @spec register() :: :ok
   def register do
     Minga.Config.Advice.register(:around, :insert_newline, &smart_newline/2)
+
+    # Refresh inline markup decorations after cursor movement and edits.
+    # :after advice runs after the command completes, so decorations
+    # reflect the new cursor position (revealing delimiters on cursor line).
+    for cmd <- [:move_up, :move_down, :move_left, :move_right, :insert_newline] do
+      Minga.Config.Advice.register(:after, cmd, &Markup.refresh/1)
+    end
+
     :ok
   end
 

--- a/lib/minga_org/buffer.ex
+++ b/lib/minga_org/buffer.ex
@@ -59,6 +59,18 @@ defmodule MingaOrg.Buffer do
     Minga.Buffer.Server.apply_text_edit(buf, start_line, start_col, end_line, end_col, new_text)
   end
 
+  @doc "Returns a range of lines as a list of strings."
+  @spec get_lines(pid(), non_neg_integer(), non_neg_integer()) :: [String.t()]
+  def get_lines(buf, start_line, count) do
+    Minga.Buffer.Server.get_lines(buf, start_line, count)
+  end
+
+  @doc "Executes a batch of decoration operations atomically."
+  @spec batch_decorations(pid(), (struct() -> struct())) :: :ok
+  def batch_decorations(buf, fun) when is_function(fun, 1) do
+    Minga.Buffer.Server.batch_decorations(buf, fun)
+  end
+
   @doc "Applies multiple text edits in a single call."
   @spec apply_text_edits(pid(), [tuple()]) :: :ok
   def apply_text_edits(buf, edits) do

--- a/lib/minga_org/inline.ex
+++ b/lib/minga_org/inline.ex
@@ -1,0 +1,192 @@
+defmodule MingaOrg.Inline do
+  @moduledoc """
+  Inline markup parser for org-mode.
+
+  Parses org inline markup within a single line of text. Org-mode
+  supports five markup types, each delimited by a specific character:
+
+  | Delimiter | Type          | Style        |
+  |-----------|---------------|--------------|
+  | `*`       | bold          | bold         |
+  | `/`       | italic        | italic       |
+  | `~`       | code          | code bg      |
+  | `=`       | verbatim      | distinct fg  |
+  | `+`       | strikethrough | strikethrough|
+
+  ## Org spec rules
+
+  - Markup only applies within a single line (no multi-line spans)
+  - Nested markup is not supported (`*/bold italic/*` is not valid)
+  - Opening delimiter must be preceded by whitespace, start of line,
+    or one of `-('{"`
+  - Closing delimiter must be followed by whitespace, end of line,
+    or one of `-.,:!?;')}"]`
+  - Content between delimiters must be non-empty
+
+  All public functions are pure (text in, spans out).
+  Positions are codepoint offsets (not byte offsets) matching Minga's
+  buffer column convention.
+  """
+
+  @typedoc "Markup type."
+  @type markup_type :: :bold | :italic | :code | :verbatim | :strikethrough
+
+  defmodule Span do
+    @moduledoc "A parsed inline markup span with codepoint positions."
+
+    @enforce_keys [:type, :start, :end_, :content_start, :content_end, :content]
+    defstruct [:type, :start, :end_, :content_start, :content_end, :content]
+
+    @type t :: %__MODULE__{
+            type: MingaOrg.Inline.markup_type(),
+            start: non_neg_integer(),
+            end_: non_neg_integer(),
+            content_start: non_neg_integer(),
+            content_end: non_neg_integer(),
+            content: String.t()
+          }
+  end
+
+  @type span :: Span.t()
+
+  @delimiter_types %{
+    "*" => :bold,
+    "/" => :italic,
+    "~" => :code,
+    "=" => :verbatim,
+    "+" => :strikethrough
+  }
+
+  @delimiters Map.keys(@delimiter_types)
+
+  # Characters that can precede an opening delimiter
+  @pre_set MapSet.new([" ", "\t", "\n", "-", "(", "'", "\"", "{"])
+  # Characters that can follow a closing delimiter
+  @post_set MapSet.new([
+              " ",
+              "\t",
+              "\n",
+              "-",
+              ".",
+              ",",
+              ":",
+              "!",
+              "?",
+              ";",
+              "'",
+              "\"",
+              ")",
+              "}",
+              "]"
+            ])
+
+  @doc """
+  Parses all inline markup spans in a line of text.
+
+  Returns a list of `Span` structs sorted by start position.
+  All positions are codepoint offsets (matching Minga's column convention).
+  Spans do not overlap (first match wins at each position).
+
+  ## Examples
+
+      iex> MingaOrg.Inline.parse("This is *bold* and /italic/ text")
+      [
+        %MingaOrg.Inline.Span{type: :bold, start: 8, end_: 14, content_start: 9, content_end: 13, content: "bold"},
+        %MingaOrg.Inline.Span{type: :italic, start: 19, end_: 27, content_start: 20, content_end: 26, content: "italic"}
+      ]
+
+      iex> MingaOrg.Inline.parse("No markup here")
+      []
+  """
+  @spec parse(String.t()) :: [span()]
+  def parse(line) when is_binary(line) do
+    graphemes = String.graphemes(line)
+
+    parse_graphemes(graphemes, 0, nil, [])
+    |> Enum.reverse()
+  end
+
+  @doc """
+  Returns the style attributes for a given markup type.
+
+  These map to Minga's highlight range style options.
+  """
+  @spec style_for(markup_type()) :: keyword()
+  def style_for(:bold), do: [bold: true]
+  def style_for(:italic), do: [italic: true]
+  def style_for(:code), do: [bg: 0x3B3B3B]
+  def style_for(:verbatim), do: [fg: 0x98C379]
+  def style_for(:strikethrough), do: [strikethrough: true]
+
+  # ── Private: parser ────────────────────────────────────────────────────────
+
+  # Walk graphemes one at a time, tracking position (codepoint index).
+  # `prev` is the previous grapheme (nil at start of line).
+  @spec parse_graphemes([String.t()], non_neg_integer(), String.t() | nil, [span()]) :: [span()]
+  defp parse_graphemes([], _pos, _prev, acc), do: acc
+
+  defp parse_graphemes([g | rest], pos, prev, acc) do
+    if g in @delimiters and valid_pre_grapheme?(prev) do
+      case find_closing_grapheme(rest, g, pos + 1) do
+        {:ok, close_pos, content_graphemes, remaining} ->
+          content = Enum.join(content_graphemes)
+
+          span = %Span{
+            type: Map.fetch!(@delimiter_types, g),
+            start: pos,
+            end_: close_pos + 1,
+            content_start: pos + 1,
+            content_end: close_pos,
+            content: content
+          }
+
+          # Continue parsing after the closing delimiter
+          next_prev = g
+          parse_after_close(remaining, close_pos + 1, next_prev, [span | acc])
+
+        :not_found ->
+          parse_graphemes(rest, pos + 1, g, acc)
+      end
+    else
+      parse_graphemes(rest, pos + 1, g, acc)
+    end
+  end
+
+  # After finding a closing delimiter, continue with the remaining graphemes.
+  # The character right after the close is already validated as post-context.
+  @spec parse_after_close([String.t()], non_neg_integer(), String.t(), [span()]) :: [span()]
+  defp parse_after_close(remaining, pos, prev, acc) do
+    parse_graphemes(remaining, pos, prev, acc)
+  end
+
+  # Check pre-context: nil (start of line) or a member of @pre_set.
+  @spec valid_pre_grapheme?(String.t() | nil) :: boolean()
+  defp valid_pre_grapheme?(nil), do: true
+  defp valid_pre_grapheme?(prev), do: MapSet.member?(@pre_set, prev)
+
+  # Search for the closing delimiter in the remaining graphemes.
+  # Must have at least 1 grapheme of content between open and close.
+  # Returns {:ok, close_pos, content_graphemes, remaining_after_close} or :not_found.
+  @spec find_closing_grapheme([String.t()], String.t(), non_neg_integer()) ::
+          {:ok, non_neg_integer(), [String.t()], [String.t()]} | :not_found
+  defp find_closing_grapheme(graphemes, delimiter, start_pos) do
+    do_find_close(graphemes, delimiter, start_pos, [])
+  end
+
+  @spec do_find_close([String.t()], String.t(), non_neg_integer(), [String.t()]) ::
+          {:ok, non_neg_integer(), [String.t()], [String.t()]} | :not_found
+  defp do_find_close([], _delimiter, _pos, _content), do: :not_found
+
+  defp do_find_close([g | rest], delimiter, pos, content) do
+    if g == delimiter and content != [] and valid_post_grapheme?(rest) do
+      {:ok, pos, Enum.reverse(content), rest}
+    else
+      do_find_close(rest, delimiter, pos + 1, [g | content])
+    end
+  end
+
+  # Check post-context: end of line (empty rest) or next grapheme in @post_set.
+  @spec valid_post_grapheme?([String.t()]) :: boolean()
+  defp valid_post_grapheme?([]), do: true
+  defp valid_post_grapheme?([next | _]), do: MapSet.member?(@post_set, next)
+end

--- a/lib/minga_org/markup.ex
+++ b/lib/minga_org/markup.ex
@@ -1,0 +1,145 @@
+defmodule MingaOrg.Markup do
+  @moduledoc """
+  Applies inline markup decorations to an org buffer.
+
+  Parses visible lines for inline markup and applies highlight ranges
+  (for styled content) and conceal ranges (for hidden delimiters) via
+  Minga's decoration system.
+
+  Decorations are applied in a batch to avoid per-line GenServer
+  round-trips. All org markup decorations use the `:org_markup` group
+  for bulk removal on refresh.
+
+  ## Refresh strategy
+
+  `refresh/1` is called after buffer changes (via advice on relevant
+  commands) or when the cursor moves to a new line (to reveal/conceal
+  delimiters). It clears all `:org_markup` decorations and reapplies
+  them for the current buffer content.
+  """
+
+  alias MingaOrg.Buffer
+  alias MingaOrg.Inline
+
+  @group :org_markup
+
+  @doc """
+  Refreshes inline markup decorations for the active org buffer.
+
+  Clears existing org markup decorations and reapplies them based on
+  current buffer content. The cursor line is excluded from concealing
+  (delimiters are visible for editing).
+
+  This is a state -> state function suitable for use as command advice.
+  """
+  @spec refresh(map()) :: map()
+  def refresh(state) do
+    buf = state.buffers.active
+
+    if Buffer.filetype(buf) == :org do
+      apply_decorations(buf)
+    end
+
+    state
+  end
+
+  @doc """
+  Applies inline markup decorations for all lines in the buffer.
+
+  Uses `batch_decorations/2` for efficient bulk application.
+  The cursor line has highlights but no conceals (delimiters visible).
+  """
+  @spec apply_decorations(pid()) :: :ok
+  def apply_decorations(buf) do
+    total = Buffer.line_count(buf)
+    {cursor_line, _col} = Buffer.cursor(buf)
+
+    # Single GenServer call to fetch all lines
+    lines = Buffer.get_lines(buf, 0, total)
+
+    # Compute decoration descriptors (pure calculation)
+    descriptors = compute_descriptors(lines, cursor_line)
+
+    # Apply decorations in a single batch (action)
+    Buffer.batch_decorations(buf, fn decs ->
+      decs = Minga.Buffer.Decorations.remove_group(decs, @group)
+      apply_descriptors(decs, descriptors)
+    end)
+  end
+
+  @doc """
+  Computes decoration descriptors for a list of lines.
+
+  Pure function: takes lines and cursor position, returns a list of
+  decoration operations. No side effects.
+  """
+  @spec compute_descriptors([String.t()], non_neg_integer()) :: [descriptor()]
+  def compute_descriptors(lines, cursor_line) do
+    lines
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {text, line_num} ->
+      spans = Inline.parse(text)
+      descriptors_for_spans(line_num, spans, line_num == cursor_line)
+    end)
+  end
+
+  @typedoc "A decoration descriptor (pure data, no side effects)."
+  @type descriptor ::
+          {:highlight, non_neg_integer(), Inline.span()}
+          | {:conceal, non_neg_integer(), non_neg_integer()}
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec descriptors_for_spans(non_neg_integer(), [Inline.span()], boolean()) :: [descriptor()]
+  defp descriptors_for_spans(_line_num, [], _cursor_line), do: []
+
+  defp descriptors_for_spans(line_num, spans, cursor_line) do
+    Enum.flat_map(spans, fn span ->
+      highlight = [{:highlight, line_num, span}]
+
+      conceals =
+        if cursor_line do
+          []
+        else
+          [
+            {:conceal, line_num, span.start},
+            {:conceal, line_num, span.end_ - 1}
+          ]
+        end
+
+      highlight ++ conceals
+    end)
+  end
+
+  @spec apply_descriptors(struct(), [descriptor()]) :: struct()
+  defp apply_descriptors(decs, descriptors) do
+    Enum.reduce(descriptors, decs, fn descriptor, decs ->
+      apply_descriptor(decs, descriptor)
+    end)
+  end
+
+  @spec apply_descriptor(struct(), descriptor()) :: struct()
+  defp apply_descriptor(decs, {:highlight, line_num, span}) do
+    style = Inline.style_for(span.type)
+    start_pos = {line_num, span.content_start}
+    end_pos = {line_num, span.content_end}
+
+    {_id, decs} =
+      Minga.Buffer.Decorations.add_highlight(decs, start_pos, end_pos,
+        style: style,
+        group: @group
+      )
+
+    decs
+  end
+
+  defp apply_descriptor(decs, {:conceal, line_num, col}) do
+    start_pos = {line_num, col}
+    end_pos = {line_num, col + 1}
+
+    {_id, decs} =
+      Minga.Buffer.Decorations.add_conceal(decs, start_pos, end_pos, group: @group)
+
+    decs
+  end
+end

--- a/test/minga_org/inline_test.exs
+++ b/test/minga_org/inline_test.exs
@@ -1,0 +1,185 @@
+defmodule MingaOrg.InlineTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Inline
+  alias MingaOrg.Inline.Span
+
+  describe "parse/1" do
+    test "parses bold markup" do
+      assert [%Span{type: :bold, content: "bold", start: 0, end_: 6}] =
+               Inline.parse("*bold* text")
+    end
+
+    test "parses italic markup" do
+      assert [%Span{type: :italic, content: "italic"}] = Inline.parse("/italic/ text")
+    end
+
+    test "parses code markup" do
+      assert [%Span{type: :code, content: "code"}] = Inline.parse("~code~ text")
+    end
+
+    test "parses verbatim markup" do
+      assert [%Span{type: :verbatim, content: "verbatim"}] = Inline.parse("=verbatim= text")
+    end
+
+    test "parses strikethrough markup" do
+      assert [%Span{type: :strikethrough, content: "deleted"}] = Inline.parse("+deleted+ text")
+    end
+
+    test "parses multiple markup spans in one line" do
+      spans = Inline.parse("This is *bold* and /italic/ text")
+      assert length(spans) == 2
+      assert Enum.at(spans, 0).type == :bold
+      assert Enum.at(spans, 0).content == "bold"
+      assert Enum.at(spans, 1).type == :italic
+      assert Enum.at(spans, 1).content == "italic"
+    end
+
+    test "returns empty list for no markup" do
+      assert [] = Inline.parse("No markup here")
+    end
+
+    test "returns empty list for empty string" do
+      assert [] = Inline.parse("")
+    end
+
+    test "requires non-empty content" do
+      assert [] = Inline.parse("** not bold")
+    end
+
+    test "markup at start of line" do
+      assert [%Span{type: :bold, content: "start", start: 0}] = Inline.parse("*start* of line")
+    end
+
+    test "markup at end of line" do
+      assert [%Span{type: :bold, content: "end"}] = Inline.parse("at the *end*")
+    end
+
+    test "markup spanning entire line" do
+      assert [%Span{type: :bold, content: "all bold"}] = Inline.parse("*all bold*")
+    end
+
+    test "opening delimiter must be preceded by whitespace or start of line" do
+      assert [] = Inline.parse("no*bold*here")
+    end
+
+    test "closing delimiter must be followed by whitespace or end of line" do
+      assert [] = Inline.parse("*bold*nope")
+    end
+
+    test "closing delimiter followed by punctuation is valid" do
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("*bold*.")
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("*bold*,")
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("*bold*!")
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("*bold*?")
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("*bold*;")
+    end
+
+    test "opening delimiter after punctuation is valid" do
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("(*bold*)")
+      assert [%Span{type: :bold, content: "bold"}] = Inline.parse("\"*bold*\"")
+    end
+
+    test "does not nest markup" do
+      spans = Inline.parse("*bold /text/*")
+      assert length(spans) == 1
+      assert hd(spans).type == :bold
+      assert hd(spans).content == "bold /text/"
+    end
+
+    test "handles adjacent markup spans" do
+      spans = Inline.parse("*bold* /italic/")
+      assert length(spans) == 2
+      assert Enum.at(spans, 0).type == :bold
+      assert Enum.at(spans, 1).type == :italic
+    end
+
+    test "handles markup with unicode content" do
+      assert [%Span{type: :bold, content: "ünïcödé"}] = Inline.parse("*ünïcödé*")
+    end
+
+    test "codepoint positions correct for ASCII" do
+      [span] = Inline.parse("hello *world* end")
+      assert span.start == 6
+      assert span.content_start == 7
+      assert span.content_end == 12
+      assert span.end_ == 13
+      assert span.content == "world"
+    end
+
+    test "codepoint positions correct with multi-byte characters before markup" do
+      # "café " is 5 codepoints (c=1, a=1, f=1, é=1, space=1)
+      # but 6 bytes (é is 2 bytes in UTF-8)
+      [span] = Inline.parse("café *bold*")
+      assert span.start == 5
+      assert span.content_start == 6
+      assert span.content_end == 10
+      assert span.end_ == 11
+    end
+
+    test "codepoint positions correct with emoji before markup" do
+      # "🎉 " is 2 codepoints (emoji=1, space=1) but 5 bytes
+      [span] = Inline.parse("🎉 *bold*")
+      assert span.start == 2
+      assert span.content_start == 3
+      assert span.content_end == 7
+      assert span.end_ == 8
+    end
+
+    test "handles code with special characters inside" do
+      assert [%Span{type: :code, content: "x + y = z"}] = Inline.parse("~x + y = z~")
+    end
+
+    test "single character content is valid" do
+      assert [%Span{type: :bold, content: "x"}] = Inline.parse("*x*")
+    end
+
+    test "unmatched opening delimiter is ignored" do
+      assert [] = Inline.parse("*no closing")
+    end
+
+    test "unmatched closing delimiter is ignored" do
+      assert [] = Inline.parse("no opening*")
+    end
+
+    test "multiple same-type spans" do
+      spans = Inline.parse("*one* and *two*")
+      assert length(spans) == 2
+      assert Enum.at(spans, 0).content == "one"
+      assert Enum.at(spans, 1).content == "two"
+    end
+
+    test "mixed types interleaved" do
+      spans = Inline.parse("*bold* then ~code~ then /italic/")
+      types = Enum.map(spans, & &1.type)
+      assert types == [:bold, :code, :italic]
+    end
+
+    test "delimiter inside code/verbatim is literal" do
+      assert [%Span{type: :code, content: "code *with* stars"}] =
+               Inline.parse("~code *with* stars~")
+    end
+  end
+
+  describe "style_for/1" do
+    test "bold returns bold style" do
+      assert [bold: true] = Inline.style_for(:bold)
+    end
+
+    test "italic returns italic style" do
+      assert [italic: true] = Inline.style_for(:italic)
+    end
+
+    test "code returns background style" do
+      assert [bg: _] = Inline.style_for(:code)
+    end
+
+    test "verbatim returns foreground style" do
+      assert [fg: _] = Inline.style_for(:verbatim)
+    end
+
+    test "strikethrough returns strikethrough style" do
+      assert [strikethrough: true] = Inline.style_for(:strikethrough)
+    end
+  end
+end

--- a/test/minga_org/markup_test.exs
+++ b/test/minga_org/markup_test.exs
@@ -1,0 +1,60 @@
+defmodule MingaOrg.MarkupTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Markup
+
+  describe "compute_descriptors/2" do
+    test "returns empty for lines without markup" do
+      assert [] = Markup.compute_descriptors(["plain text", "no markup"], 0)
+    end
+
+    test "produces highlight and conceal descriptors for markup" do
+      descriptors = Markup.compute_descriptors(["*bold* text"], 99)
+
+      highlights = Enum.filter(descriptors, &match?({:highlight, _, _}, &1))
+      conceals = Enum.filter(descriptors, &match?({:conceal, _, _}, &1))
+
+      assert length(highlights) == 1
+      assert length(conceals) == 2
+
+      [{:highlight, 0, span}] = highlights
+      assert span.type == :bold
+      assert span.content == "bold"
+    end
+
+    test "skips conceals on cursor line" do
+      descriptors = Markup.compute_descriptors(["*bold* text"], 0)
+
+      highlights = Enum.filter(descriptors, &match?({:highlight, _, _}, &1))
+      conceals = Enum.filter(descriptors, &match?({:conceal, _, _}, &1))
+
+      assert length(highlights) == 1
+      assert length(conceals) == 0
+    end
+
+    test "handles multiple lines with different markup" do
+      lines = ["*bold*", "plain", "/italic/"]
+      descriptors = Markup.compute_descriptors(lines, 99)
+
+      highlights = Enum.filter(descriptors, &match?({:highlight, _, _}, &1))
+      assert length(highlights) == 2
+
+      types = Enum.map(highlights, fn {:highlight, _, span} -> span.type end)
+      assert :bold in types
+      assert :italic in types
+    end
+
+    test "conceal positions match delimiter positions" do
+      descriptors = Markup.compute_descriptors(["hello *world* end"], 99)
+
+      conceals =
+        descriptors
+        |> Enum.filter(&match?({:conceal, _, _}, &1))
+        |> Enum.map(fn {:conceal, _line, col} -> col end)
+        |> Enum.sort()
+
+      # Opening * at col 6, closing * at col 12
+      assert conceals == [6, 12]
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds inline markup rendering for org-mode (#6). Tree-sitter-org doesn't parse inline markup, so this uses an Elixir-side parser.

### Parser (`MingaOrg.Inline`)
- Parses `*bold*`, `/italic/`, `~code~`, `=verbatim=`, `+strikethrough+`
- Follows org spec boundary rules (pre/post context characters)
- Returns `Span` structs with **codepoint offsets** (not byte offsets) matching Minga's column convention
- Handles multi-byte UTF-8 correctly (tested with accented chars, emoji)
- No nesting, single-line only, first-match-wins

### Decoration applicator (`MingaOrg.Markup`)
- Pure `compute_descriptors/2` separates calculation from action
- Single `get_lines` call fetches all lines (no N+1 GenServer round-trips)
- Applies highlight ranges for styled content + conceal ranges for delimiters
- Cursor line shows raw delimiters for editing (conceallevel=2 behavior)
- Uses `batch_decorations` for efficient atomic application
- `:after` advice on cursor movement refreshes decorations

### Deferred
- Concealing toggle via config (needs extension config support in Minga core)

## Testing
34 parser tests + 5 markup descriptor tests. 125 total, 0 failures.

Closes #6