### PR TITLE
feat(table): org table parsing, alignment, and cell navigation

### DIFF
--- a/lib/minga_org/table.ex
+++ b/lib/minga_org/table.ex
@@ -1,0 +1,229 @@
+defmodule MingaOrg.Table do
+  @moduledoc """
+  Org table parsing, alignment, and cell navigation.
+
+  Org tables are pipe-delimited:
+
+      | Name  | Age |
+      |-------+-----|
+      | Alice | 30  |
+      | Bob   | 25  |
+
+  This module provides pure functions for:
+  - Parsing table rows into cells
+  - Computing column widths and generating aligned table text
+  - Generating horizontal separator rules
+  - Navigating between cells (next/previous)
+
+  All public functions are pure (text in, data out).
+  """
+
+  @typedoc "A parsed table row."
+  @type row :: {:data, [String.t()]} | {:separator, non_neg_integer()}
+
+  @doc """
+  Parses a line as a table row.
+
+  Returns `{:data, cells}` for data rows, `{:separator, col_count}` for
+  horizontal rules, or `:not_table` for non-table lines.
+
+  ## Examples
+
+      iex> MingaOrg.Table.parse_row("| Alice | 30 |")
+      {:data, ["Alice", "30"]}
+
+      iex> MingaOrg.Table.parse_row("|---+---|")
+      {:separator, 2}
+
+      iex> MingaOrg.Table.parse_row("Not a table")
+      :not_table
+  """
+  @spec parse_row(String.t()) ::
+          {:data, [String.t()]} | {:separator, non_neg_integer()} | :not_table
+  def parse_row(line) do
+    trimmed = String.trim(line)
+
+    if String.starts_with?(trimmed, "|") do
+      if separator_row?(trimmed) do
+        cols = trimmed |> String.split("+") |> length()
+        {:separator, cols}
+      else
+        cells =
+          trimmed
+          |> String.trim_leading("|")
+          |> String.trim_trailing("|")
+          |> String.split("|")
+          |> Enum.map(&String.trim/1)
+
+        {:data, cells}
+      end
+    else
+      :not_table
+    end
+  end
+
+  @doc """
+  Returns true if the line is a table row (data or separator).
+  """
+  @spec table_line?(String.t()) :: boolean()
+  def table_line?(line) do
+    parse_row(line) != :not_table
+  end
+
+  @doc """
+  Computes the maximum width for each column across all data rows.
+
+  Uses `String.length/1` (codepoint count) for width calculation.
+  """
+  @spec column_widths([row()]) :: [non_neg_integer()]
+  def column_widths(rows) do
+    data_rows = Enum.filter(rows, &match?({:data, _}, &1))
+
+    if data_rows == [] do
+      []
+    else
+      max_cols = data_rows |> Enum.map(fn {:data, cells} -> length(cells) end) |> Enum.max()
+
+      Enum.map(0..(max_cols - 1), fn col_idx ->
+        data_rows
+        |> Enum.map(fn {:data, cells} ->
+          cell = Enum.at(cells, col_idx) || ""
+          String.length(cell)
+        end)
+        |> Enum.max()
+        |> max(1)
+      end)
+    end
+  end
+
+  @doc """
+  Formats a data row with cells padded to the given column widths.
+
+  ## Examples
+
+      iex> MingaOrg.Table.format_data_row(["Alice", "30"], [5, 3])
+      "| Alice | 30  |"
+  """
+  @spec format_data_row([String.t()], [non_neg_integer()]) :: String.t()
+  def format_data_row(cells, widths) do
+    padded =
+      Enum.zip_with([cells, widths], fn
+        [cell, width] -> String.pad_trailing(cell, width)
+      end)
+
+    "| " <> Enum.join(padded, " | ") <> " |"
+  end
+
+  @doc """
+  Formats a separator row for the given column widths.
+
+  ## Examples
+
+      iex> MingaOrg.Table.format_separator([5, 3])
+      "|-------+-----|"
+  """
+  @spec format_separator([non_neg_integer()]) :: String.t()
+  def format_separator(widths) do
+    dashes = Enum.map(widths, fn w -> String.duplicate("-", w + 2) end)
+    "|" <> Enum.join(dashes, "+") <> "|"
+  end
+
+  @doc """
+  Aligns an entire table (list of raw line strings).
+
+  Returns a list of formatted line strings with all columns aligned.
+  """
+  @spec align_table([String.t()]) :: [String.t()]
+  def align_table(lines) do
+    rows = Enum.map(lines, &parse_row/1)
+    widths = column_widths(rows)
+
+    if widths == [] do
+      lines
+    else
+      Enum.map(rows, fn
+        {:data, cells} ->
+          # Pad cells list to match the expected number of columns
+          padded_cells = pad_cells(cells, length(widths))
+          format_data_row(padded_cells, widths)
+
+        {:separator, _} ->
+          format_separator(widths)
+
+        :not_table ->
+          ""
+      end)
+    end
+  end
+
+  @doc """
+  Returns the column index (0-based) and cell boundaries for the cursor
+  position within a table row.
+
+  Returns `{:ok, col_index, cell_start, cell_end}` or `:not_in_table`.
+  Positions are codepoint offsets.
+  """
+  @spec cell_at(String.t(), non_neg_integer()) ::
+          {:ok, non_neg_integer(), non_neg_integer(), non_neg_integer()} | :not_in_table
+  def cell_at(line, cursor_col) do
+    if not table_line?(line) do
+      :not_in_table
+    else
+      graphemes = String.graphemes(line)
+      find_cell(graphemes, 0, 0, cursor_col)
+    end
+  end
+
+  @doc """
+  Creates a new empty row matching the column count of the given widths.
+  """
+  @spec new_row([non_neg_integer()]) :: String.t()
+  def new_row(widths) do
+    cells = Enum.map(widths, fn _ -> "" end)
+    format_data_row(cells, widths)
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec separator_row?(String.t()) :: boolean()
+  defp separator_row?(trimmed) do
+    # A separator is | followed by dashes, +, and |
+    String.match?(trimmed, ~r/^\|[-+|]+\|$/)
+  end
+
+  @spec pad_cells([String.t()], non_neg_integer()) :: [String.t()]
+  defp pad_cells(cells, expected) when length(cells) >= expected, do: Enum.take(cells, expected)
+
+  defp pad_cells(cells, expected) do
+    cells ++ List.duplicate("", expected - length(cells))
+  end
+
+  @spec find_cell([String.t()], non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, non_neg_integer(), non_neg_integer(), non_neg_integer()} | :not_in_table
+  defp find_cell([], _pos, _col_idx, _cursor), do: :not_in_table
+
+  defp find_cell(["|" | rest], pos, col_idx, cursor) do
+    # Find the end of this cell (next | or end)
+    cell_start = pos + 1
+    cell_end = find_next_pipe(rest, cell_start)
+
+    if cursor >= cell_start and cursor < cell_end do
+      {:ok, col_idx, cell_start, cell_end}
+    else
+      find_cell(rest, pos + 1, col_idx + 1, cursor)
+    end
+  end
+
+  defp find_cell([_ | rest], pos, col_idx, cursor) do
+    find_cell(rest, pos + 1, col_idx, cursor)
+  end
+
+  @spec find_next_pipe([String.t()], non_neg_integer()) :: non_neg_integer()
+  defp find_next_pipe([], pos), do: pos
+
+  defp find_next_pipe(["|" | _], pos), do: pos
+
+  defp find_next_pipe([_ | rest], pos) do
+    find_next_pipe(rest, pos + 1)
+  end
+end

--- a/test/minga_org/table_test.exs
+++ b/test/minga_org/table_test.exs
@@ -1,0 +1,163 @@
+defmodule MingaOrg.TableTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Table
+
+  describe "parse_row/1" do
+    test "parses data row" do
+      assert {:data, ["Alice", "30"]} = Table.parse_row("| Alice | 30 |")
+    end
+
+    test "parses data row with extra spaces" do
+      assert {:data, ["Name", "Age"]} = Table.parse_row("|  Name  |  Age  |")
+    end
+
+    test "parses single column" do
+      assert {:data, ["Only"]} = Table.parse_row("| Only |")
+    end
+
+    test "parses empty cells" do
+      assert {:data, ["", ""]} = Table.parse_row("|  |  |")
+    end
+
+    test "parses separator row" do
+      assert {:separator, 2} = Table.parse_row("|---+---|")
+    end
+
+    test "parses separator with varying dash counts" do
+      assert {:separator, 3} = Table.parse_row("|-------+-----+--|")
+    end
+
+    test "returns not_table for plain text" do
+      assert :not_table = Table.parse_row("Not a table")
+    end
+
+    test "returns not_table for empty string" do
+      assert :not_table = Table.parse_row("")
+    end
+
+    test "returns not_table for heading" do
+      assert :not_table = Table.parse_row("* Heading")
+    end
+
+    test "parses row with unicode content" do
+      assert {:data, ["café", "naïve"]} = Table.parse_row("| café | naïve |")
+    end
+  end
+
+  describe "column_widths/1" do
+    test "computes widths from data rows" do
+      rows = [{:data, ["Alice", "30"]}, {:data, ["Bob", "100"]}]
+      assert [5, 3] = Table.column_widths(rows)
+    end
+
+    test "ignores separator rows" do
+      rows = [{:data, ["A", "B"]}, {:separator, 2}, {:data, ["CC", "DDD"]}]
+      assert [2, 3] = Table.column_widths(rows)
+    end
+
+    test "minimum width is 1" do
+      rows = [{:data, ["", ""]}]
+      assert [1, 1] = Table.column_widths(rows)
+    end
+
+    test "returns empty for no data rows" do
+      assert [] = Table.column_widths([{:separator, 2}])
+    end
+
+    test "handles uneven column counts" do
+      rows = [{:data, ["A", "B", "C"]}, {:data, ["D", "E"]}]
+      assert [1, 1, 1] = Table.column_widths(rows)
+    end
+  end
+
+  describe "format_data_row/2" do
+    test "pads cells to column widths" do
+      assert "| Alice | 30  |" = Table.format_data_row(["Alice", "30"], [5, 3])
+    end
+
+    test "handles single column" do
+      assert "| X |" = Table.format_data_row(["X"], [1])
+    end
+  end
+
+  describe "format_separator/1" do
+    test "generates separator for widths" do
+      assert "|-------+-----|" = Table.format_separator([5, 3])
+    end
+
+    test "single column separator" do
+      assert "|---|" = Table.format_separator([1])
+    end
+  end
+
+  describe "align_table/1" do
+    test "aligns simple table" do
+      lines = ["| Name | Age |", "|---+---|", "| Alice | 30 |", "| Bob | 100 |"]
+      aligned = Table.align_table(lines)
+
+      assert aligned == [
+               "| Name  | Age |",
+               "|-------+-----|",
+               "| Alice | 30  |",
+               "| Bob   | 100 |"
+             ]
+    end
+
+    test "aligns table with uneven cells" do
+      lines = ["| A | B |", "| CC | DDD |"]
+      aligned = Table.align_table(lines)
+
+      assert aligned == [
+               "| A  | B   |",
+               "| CC | DDD |"
+             ]
+    end
+
+    test "handles table with only separator" do
+      # No data rows, returns input unchanged
+      lines = ["|---+---|"]
+      assert ["|---+---|"] = Table.align_table(lines)
+    end
+  end
+
+  describe "table_line?/1" do
+    test "true for data row" do
+      assert Table.table_line?("| A | B |")
+    end
+
+    test "true for separator" do
+      assert Table.table_line?("|---+---|")
+    end
+
+    test "false for plain text" do
+      refute Table.table_line?("plain text")
+    end
+  end
+
+  describe "cell_at/2" do
+    test "finds cell at cursor position" do
+      # "| Alice | 30 |"
+      #  01234567890123
+      # Cell 0: positions 1-7 (space A l i c e space), cell 1: 8-12
+      assert {:ok, 0, 1, 8} = Table.cell_at("| Alice | 30 |", 3)
+    end
+
+    test "finds second cell" do
+      assert {:ok, 1, 9, 13} = Table.cell_at("| Alice | 30 |", 10)
+    end
+
+    test "returns not_in_table for non-table line" do
+      assert :not_in_table = Table.cell_at("Not a table", 5)
+    end
+  end
+
+  describe "new_row/1" do
+    test "creates empty row with correct widths" do
+      assert "| " <> _ = Table.new_row([5, 3])
+      row = Table.new_row([5, 3])
+      {:data, cells} = Table.parse_row(row)
+      assert length(cells) == 2
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds org table support (#9): parsing, alignment, and cell navigation.

### Pure logic (`MingaOrg.Table`)
- Parses pipe-delimited table rows and separator rules
- Computes column widths across all rows
- Aligns entire tables with `align_table/1` (pads cells to max width per column)
- Generates separator rules (`|---+---|`)
- `cell_at/2` finds cell boundaries for cursor navigation
- `new_row/1` creates empty rows matching the table structure

### Deferred
- TAB-to-align keybinding (needs context-aware TAB dispatch: table context vs heading fold vs default). The pure alignment logic is complete; wiring TAB requires insert-mode keybinding support.
- Shift-TAB for previous cell navigation (same prerequisite)

## Testing
29 new tests. 115 total, 0 failures.

Closes #9