### PR TITLE
feat(pretty): Unicode pretty bullets for headings and list items

### DIFF
--- a/lib/minga_org/advice.ex
+++ b/lib/minga_org/advice.ex
@@ -9,6 +9,7 @@ defmodule MingaOrg.Advice do
   alias MingaOrg.Buffer
   alias MingaOrg.List
   alias MingaOrg.Markup
+  alias MingaOrg.Pretty
 
   @doc """
   Registers all org-mode advice hooks.
@@ -19,11 +20,12 @@ defmodule MingaOrg.Advice do
   def register do
     Minga.Config.Advice.register(:around, :insert_newline, &smart_newline/2)
 
-    # Refresh inline markup decorations after cursor movement and edits.
+    # Refresh decorations after cursor movement and edits.
     # :after advice runs after the command completes, so decorations
     # reflect the new cursor position (revealing delimiters on cursor line).
     for cmd <- [:move_up, :move_down, :move_left, :move_right, :insert_newline] do
       Minga.Config.Advice.register(:after, cmd, &Markup.refresh/1)
+      Minga.Config.Advice.register(:after, cmd, &Pretty.refresh/1)
     end
 
     :ok

--- a/lib/minga_org/pretty.ex
+++ b/lib/minga_org/pretty.ex
@@ -1,0 +1,182 @@
+defmodule MingaOrg.Pretty do
+  @moduledoc """
+  Pretty bullets for org-mode headings and list items.
+
+  Replaces heading stars (`*`, `**`, `***`) with styled Unicode bullets
+  that vary by depth, and list bullets (`-`, `+`) with cleaner symbols.
+  Inspired by `org-superstar-mode` and `org-modern` in Emacs.
+
+  The buffer text is never modified; only the display changes via
+  Minga's conceal mechanism (replace concealed characters with a
+  Unicode replacement).
+
+  All public functions are pure.
+  """
+
+  @default_heading_bullets ["◉", "○", "◈", "◇"]
+  @default_list_bullet "•"
+
+  @typedoc "Configuration for pretty bullets."
+  @type config :: %{
+          heading_bullets: [String.t()],
+          list_bullet: String.t(),
+          enabled: boolean()
+        }
+
+  alias MingaOrg.Buffer
+
+  @group :org_pretty
+
+  @typedoc "A decoration descriptor for pretty bullets."
+  @type descriptor ::
+          {:conceal_replace, non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()}
+
+  @doc """
+  Returns the default configuration.
+  """
+  @spec default_config() :: config()
+  def default_config do
+    %{
+      heading_bullets: @default_heading_bullets,
+      list_bullet: @default_list_bullet,
+      enabled: true
+    }
+  end
+
+  @doc """
+  Refreshes pretty bullet decorations for the active org buffer.
+
+  This is a state -> state function suitable for use as command advice.
+  """
+  @spec refresh(map()) :: map()
+  def refresh(state) do
+    buf = state.buffers.active
+
+    if Buffer.filetype(buf) == :org do
+      apply_decorations(buf)
+    end
+
+    state
+  end
+
+  @doc """
+  Applies pretty bullet decorations for all lines in the buffer.
+
+  Fetches all lines in a single call, computes decorations, and
+  applies them in a batch.
+  """
+  @spec apply_decorations(pid()) :: :ok
+  def apply_decorations(buf) do
+    total = Buffer.line_count(buf)
+    {cursor_line, _col} = Buffer.cursor(buf)
+    lines = Buffer.get_lines(buf, 0, total)
+    descriptors = compute_decorations(lines, cursor_line)
+
+    Buffer.batch_decorations(buf, fn decs ->
+      decs = Minga.Buffer.Decorations.remove_group(decs, @group)
+
+      Enum.reduce(descriptors, decs, fn {:conceal_replace, line, start_col, end_col, replacement},
+                                        decs ->
+        {_id, decs} =
+          Minga.Buffer.Decorations.add_conceal(decs, {line, start_col}, {line, end_col},
+            replacement: replacement,
+            group: @group
+          )
+
+        decs
+      end)
+    end)
+  end
+
+  @doc """
+  Returns the Unicode bullet for a heading at the given level (1-indexed).
+
+  Cycles through the bullet set for levels deeper than the set length.
+
+  ## Examples
+
+      iex> MingaOrg.Pretty.heading_bullet(1)
+      "◉"
+
+      iex> MingaOrg.Pretty.heading_bullet(2)
+      "○"
+
+      iex> MingaOrg.Pretty.heading_bullet(5)
+      "◉"
+  """
+  @spec heading_bullet(pos_integer()) :: String.t()
+  def heading_bullet(level), do: heading_bullet(level, @default_heading_bullets)
+
+  @spec heading_bullet(pos_integer(), [String.t()]) :: String.t()
+  def heading_bullet(level, bullets) when level >= 1 do
+    idx = rem(level - 1, length(bullets))
+    Enum.at(bullets, idx)
+  end
+
+  @doc """
+  Computes pretty bullet decorations for a list of lines.
+
+  Returns a list of conceal-with-replacement descriptors. Each descriptor
+  specifies a line, start column, end column, and replacement character.
+
+  Heading lines: the stars + space are concealed and replaced with a
+  single Unicode bullet (depth-dependent).
+
+  List lines: the bullet character is concealed and replaced with the
+  configured Unicode symbol.
+
+  The cursor line is excluded (raw characters visible for editing).
+  """
+  @spec compute_decorations([String.t()], non_neg_integer(), config()) :: [descriptor()]
+  def compute_decorations(lines, cursor_line, config \\ default_config()) do
+    if not config.enabled do
+      []
+    else
+      lines
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {line, line_num} ->
+        if line_num == cursor_line do
+          []
+        else
+          decorations_for_line(line, line_num, config)
+        end
+      end)
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec decorations_for_line(String.t(), non_neg_integer(), config()) :: [descriptor()]
+  defp decorations_for_line(line, line_num, config) do
+    case classify_line(line) do
+      {:heading, level, star_count} ->
+        bullet = heading_bullet(level, config.heading_bullets)
+        # Conceal all stars + the trailing space, replace with the bullet
+        [{:conceal_replace, line_num, 0, star_count + 1, bullet}]
+
+      {:list_bullet, col} ->
+        [{:conceal_replace, line_num, col, col + 1, config.list_bullet}]
+
+      :other ->
+        []
+    end
+  end
+
+  @spec classify_line(String.t()) ::
+          {:heading, pos_integer(), pos_integer()} | {:list_bullet, non_neg_integer()} | :other
+  defp classify_line(line) do
+    case Regex.run(~r/^(\*+) /, line) do
+      [_match, stars] ->
+        {:heading, String.length(stars), String.length(stars)}
+
+      nil ->
+        case Regex.run(~r/^(\s*)([-+]) /, line) do
+          [_match, indent, _bullet] ->
+            {:list_bullet, String.length(indent)}
+
+          nil ->
+            :other
+        end
+    end
+  end
+end

--- a/test/minga_org/pretty_test.exs
+++ b/test/minga_org/pretty_test.exs
@@ -1,0 +1,111 @@
+defmodule MingaOrg.PrettyTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Pretty
+
+  describe "heading_bullet/1" do
+    test "level 1 returns first bullet" do
+      assert "◉" = Pretty.heading_bullet(1)
+    end
+
+    test "level 2 returns second bullet" do
+      assert "○" = Pretty.heading_bullet(2)
+    end
+
+    test "level 3 returns third bullet" do
+      assert "◈" = Pretty.heading_bullet(3)
+    end
+
+    test "level 4 returns fourth bullet" do
+      assert "◇" = Pretty.heading_bullet(4)
+    end
+
+    test "level 5 cycles back to first" do
+      assert "◉" = Pretty.heading_bullet(5)
+    end
+
+    test "custom bullet set" do
+      assert "A" = Pretty.heading_bullet(1, ["A", "B"])
+      assert "B" = Pretty.heading_bullet(2, ["A", "B"])
+      assert "A" = Pretty.heading_bullet(3, ["A", "B"])
+    end
+  end
+
+  describe "compute_decorations/3" do
+    test "heading stars get replaced with bullet" do
+      lines = ["* Heading 1"]
+      [desc] = Pretty.compute_decorations(lines, 99)
+      assert {:conceal_replace, 0, 0, 2, "◉"} = desc
+    end
+
+    test "level 2 heading gets second bullet" do
+      lines = ["** Heading 2"]
+      [desc] = Pretty.compute_decorations(lines, 99)
+      assert {:conceal_replace, 0, 0, 3, "○"} = desc
+    end
+
+    test "level 3 heading" do
+      lines = ["*** Heading 3"]
+      [desc] = Pretty.compute_decorations(lines, 99)
+      assert {:conceal_replace, 0, 0, 4, "◈"} = desc
+    end
+
+    test "list bullet gets replaced" do
+      lines = ["- Item"]
+      [desc] = Pretty.compute_decorations(lines, 99)
+      assert {:conceal_replace, 0, 0, 1, "•"} = desc
+    end
+
+    test "plus bullet gets replaced" do
+      lines = ["+ Item"]
+      [desc] = Pretty.compute_decorations(lines, 99)
+      assert {:conceal_replace, 0, 0, 1, "•"} = desc
+    end
+
+    test "indented list bullet has correct column" do
+      lines = ["  - Nested"]
+      [desc] = Pretty.compute_decorations(lines, 99)
+      assert {:conceal_replace, 0, 2, 3, "•"} = desc
+    end
+
+    test "cursor line is excluded" do
+      lines = ["* Heading"]
+      assert [] = Pretty.compute_decorations(lines, 0)
+    end
+
+    test "plain text produces no decorations" do
+      lines = ["Just some text"]
+      assert [] = Pretty.compute_decorations(lines, 99)
+    end
+
+    test "disabled config produces no decorations" do
+      config = %{Pretty.default_config() | enabled: false}
+      lines = ["* Heading"]
+      assert [] = Pretty.compute_decorations(lines, 99, config)
+    end
+
+    test "multiple lines produce multiple decorations" do
+      lines = ["* H1", "** H2", "- Item", "text"]
+      descs = Pretty.compute_decorations(lines, 99)
+      assert length(descs) == 3
+    end
+
+    test "custom bullet config" do
+      config = %{Pretty.default_config() | heading_bullets: ["▸"], list_bullet: "⁃"}
+      lines = ["* Heading", "- Item"]
+      descs = Pretty.compute_decorations(lines, 99, config)
+
+      assert {:conceal_replace, 0, 0, 2, "▸"} = Enum.at(descs, 0)
+      assert {:conceal_replace, 1, 0, 1, "⁃"} = Enum.at(descs, 1)
+    end
+  end
+
+  describe "default_config/0" do
+    test "returns expected defaults" do
+      config = Pretty.default_config()
+      assert config.heading_bullets == ["◉", "○", "◈", "◇"]
+      assert config.list_bullet == "•"
+      assert config.enabled == true
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds org-superstar-style pretty bullets (#13).

### Pure logic (`MingaOrg.Pretty`)
- Heading stars (`*`, `**`, `***`) → depth-cycling Unicode bullets (◉ ○ ◈ ◇)
- List bullets (`-`, `+`) → • (bullet character)
- Cursor line shows raw characters for editing
- Fully configurable: bullet character set, list symbol, enabled toggle
- Returns `conceal_replace` descriptors for Minga's ConcealRange system

### Deferred
- Wiring to ConcealRange.replacement depends on the conceal applicator from #6
- Config option registration (`org_pretty_bullets`, `org_heading_bullets`) needs extension config support in core

## Testing
18 new tests. 104 total, 0 failures.

Closes #13