### PR TITLE
feat(export): pandoc-based org export to HTML, PDF, Markdown, etc.

### DIFF
--- a/lib/minga_org/commands.ex
+++ b/lib/minga_org/commands.ex
@@ -7,6 +7,7 @@ defmodule MingaOrg.Commands do
   """
 
   alias MingaOrg.Checkbox
+  alias MingaOrg.Export
   alias MingaOrg.Folding
   alias MingaOrg.Heading
   alias MingaOrg.LinkFollow
@@ -78,6 +79,27 @@ defmodule MingaOrg.Commands do
       :org_follow_link,
       "Follow link at cursor",
       &LinkFollow.follow/1
+    )
+
+    registry.register(
+      registry,
+      :org_export_html,
+      "Export to HTML",
+      &Export.export_command(&1, "html")
+    )
+
+    registry.register(
+      registry,
+      :org_export_markdown,
+      "Export to Markdown",
+      &Export.export_command(&1, "markdown")
+    )
+
+    registry.register(
+      registry,
+      :org_export_pdf,
+      "Export to PDF",
+      &Export.export_command(&1, "pdf")
     )
 
     :ok

--- a/lib/minga_org/export.ex
+++ b/lib/minga_org/export.ex
@@ -1,0 +1,146 @@
+defmodule MingaOrg.Export do
+  @moduledoc """
+  Export org files via pandoc.
+
+  Delegates all conversion to [pandoc](https://pandoc.org/), which has
+  full org-mode reader support. Supported output formats include HTML,
+  Markdown, PDF, LaTeX, and any format pandoc supports.
+
+  Export runs asynchronously so the editor isn't blocked during
+  conversion.
+  """
+
+  alias MingaOrg.Buffer
+
+  @default_formats [
+    {"html", "HTML"},
+    {"markdown", "Markdown"},
+    {"pdf", "PDF"},
+    {"latex", "LaTeX"},
+    {"docx", "Word (docx)"},
+    {"rst", "reStructuredText"},
+    {"asciidoc", "AsciiDoc"}
+  ]
+
+  @doc """
+  Returns the list of available export formats.
+
+  Each entry is `{pandoc_format, display_name}`.
+  """
+  @spec formats() :: [{String.t(), String.t()}]
+  def formats, do: @default_formats
+
+  @doc """
+  Checks if pandoc is installed and returns its version.
+
+  Returns `{:ok, version}` or `{:error, reason}`.
+  """
+  @spec check_pandoc() :: {:ok, String.t()} | {:error, String.t()}
+  def check_pandoc do
+    case System.cmd("pandoc", ["--version"], stderr_to_stdout: true) do
+      {output, 0} ->
+        version = output |> String.split("\n") |> hd() |> String.trim()
+        {:ok, version}
+
+      {_, _} ->
+        {:error, "pandoc not found. Install it: https://pandoc.org/installing.html"}
+    end
+  rescue
+    ErlangError ->
+      {:error, "pandoc not found. Install it: https://pandoc.org/installing.html"}
+  end
+
+  @doc """
+  Exports the given file to the specified format.
+
+  Returns `{:ok, output_path}` on success or `{:error, reason}` on failure.
+  The output file is written next to the source file with the appropriate
+  extension.
+
+  ## Examples
+
+      iex> MingaOrg.Export.export("/path/to/notes.org", "html")
+      {:ok, "/path/to/notes.html"}
+  """
+  @spec export(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def export(input_path, format) do
+    output_path = output_path_for(input_path, format)
+
+    args = [input_path, "-o", output_path, "--from=org", "--to=#{format}"]
+
+    case System.cmd("pandoc", args, stderr_to_stdout: true) do
+      {_output, 0} ->
+        {:ok, output_path}
+
+      {error_output, _code} ->
+        {:error, "pandoc export failed: #{String.trim(error_output)}"}
+    end
+  rescue
+    ErlangError ->
+      {:error, "pandoc not found. Install it: https://pandoc.org/installing.html"}
+  end
+
+  @doc """
+  Exports the active buffer's file asynchronously.
+
+  This is a state -> state command function. The export runs in a
+  background task. Success/failure is logged to *Messages*.
+  """
+  @spec export_command(map(), String.t()) :: map()
+  def export_command(state, format) do
+    buf = state.buffers.active
+
+    case get_file_path(buf) do
+      {:ok, path} ->
+        Task.start(fn ->
+          case export(path, format) do
+            {:ok, output} ->
+              Minga.Editor.log_to_messages("Exported to #{output}")
+
+            {:error, reason} ->
+              Minga.Editor.log_to_messages("Export failed: #{reason}")
+          end
+        end)
+
+        state
+
+      :no_file ->
+        state
+    end
+  end
+
+  @doc """
+  Computes the output file path for a given input and format.
+
+  ## Examples
+
+      iex> MingaOrg.Export.output_path_for("/path/to/notes.org", "html")
+      "/path/to/notes.html"
+
+      iex> MingaOrg.Export.output_path_for("/path/to/notes.org", "pdf")
+      "/path/to/notes.pdf"
+  """
+  @spec output_path_for(String.t(), String.t()) :: String.t()
+  def output_path_for(input_path, format) do
+    ext = format_extension(format)
+    base = Path.rootname(input_path)
+    "#{base}.#{ext}"
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec format_extension(String.t()) :: String.t()
+  defp format_extension("markdown"), do: "md"
+  defp format_extension("latex"), do: "tex"
+  defp format_extension("asciidoc"), do: "adoc"
+  defp format_extension("rst"), do: "rst"
+  defp format_extension(format), do: format
+
+  @spec get_file_path(pid()) :: {:ok, String.t()} | :no_file
+  defp get_file_path(buf) do
+    path = Minga.Buffer.Server.file_path(buf)
+    if path, do: {:ok, path}, else: :no_file
+  rescue
+    _ -> :no_file
+  end
+end

--- a/lib/minga_org/keybindings.ex
+++ b/lib/minga_org/keybindings.ex
@@ -44,6 +44,17 @@ defmodule MingaOrg.Keybindings do
     bind.(:normal, "RET", :org_follow_link, "Follow link", filetype: :org)
     bind.(:normal, "g x", :org_follow_link, "Follow link", filetype: :org)
 
+    # ── Export ────────────────────────────────────────────────────────────────
+
+    # SPC m e h — export to HTML
+    bind.(:normal, "SPC m e h", :org_export_html, "Export to HTML", filetype: :org)
+
+    # SPC m e m — export to Markdown
+    bind.(:normal, "SPC m e m", :org_export_markdown, "Export to Markdown", filetype: :org)
+
+    # SPC m e p — export to PDF
+    bind.(:normal, "SPC m e p", :org_export_pdf, "Export to PDF", filetype: :org)
+
     # ── Folding ──────────────────────────────────────────────────────────────
 
     # TAB — toggle fold at heading

--- a/test/minga_org/export_test.exs
+++ b/test/minga_org/export_test.exs
@@ -1,0 +1,55 @@
+defmodule MingaOrg.ExportTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Export
+
+  describe "output_path_for/2" do
+    test "html extension" do
+      assert "/path/notes.html" = Export.output_path_for("/path/notes.org", "html")
+    end
+
+    test "pdf extension" do
+      assert "/path/notes.pdf" = Export.output_path_for("/path/notes.org", "pdf")
+    end
+
+    test "markdown gets .md extension" do
+      assert "/path/notes.md" = Export.output_path_for("/path/notes.org", "markdown")
+    end
+
+    test "latex gets .tex extension" do
+      assert "/path/notes.tex" = Export.output_path_for("/path/notes.org", "latex")
+    end
+
+    test "asciidoc gets .adoc extension" do
+      assert "/path/notes.adoc" = Export.output_path_for("/path/notes.org", "asciidoc")
+    end
+
+    test "rst gets .rst extension" do
+      assert "/path/notes.rst" = Export.output_path_for("/path/notes.org", "rst")
+    end
+
+    test "docx gets .docx extension" do
+      assert "/path/notes.docx" = Export.output_path_for("/path/notes.org", "docx")
+    end
+
+    test "handles nested paths" do
+      assert "/a/b/c/doc.html" = Export.output_path_for("/a/b/c/doc.org", "html")
+    end
+  end
+
+  describe "formats/0" do
+    test "returns a non-empty list of format tuples" do
+      formats = Export.formats()
+      assert length(formats) > 0
+      assert {"html", "HTML"} in formats
+      assert {"pdf", "PDF"} in formats
+    end
+  end
+
+  describe "check_pandoc/0" do
+    test "returns ok or error (integration test)" do
+      result = Export.check_pandoc()
+      assert match?({:ok, _}, result) or match?({:error, _}, result)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds pandoc-based export for org files (#12).

### `MingaOrg.Export`
- `export/2` converts org files to any pandoc-supported format
- `check_pandoc/0` verifies pandoc is installed
- `output_path_for/2` computes output path with correct extension (.md, .tex, .adoc, etc.)
- `export_command/2` runs export in a background Task (non-blocking)
- 7 default formats: HTML, Markdown, PDF, LaTeX, Word, reStructuredText, AsciiDoc
- Success/failure logged to `*Messages*`

### Deferred
- Format picker UI (`SPC m e` opens format selection) needs Minga's picker API
- Custom pandoc flags via user config

## Testing
10 new tests. 96 total, 0 failures.

Closes #12