### PR TITLE
feat(capture): quick-capture with configurable templates

### DIFF
--- a/lib/minga_org/capture.ex
+++ b/lib/minga_org/capture.ex
@@ -1,0 +1,202 @@
+defmodule MingaOrg.Capture do
+  @moduledoc """
+  Quick-capture for org-mode notes.
+
+  Capture lets you jot down a thought from anywhere in the editor and
+  have it land in the right org file under the right heading. Inspired
+  by Doom Emacs `SPC X` and Emacs's `org-capture`.
+
+  ## Templates
+
+  Capture templates define the structure of captured content:
+
+      %{
+        key: "t",
+        name: "TODO",
+        target: "~/org/inbox.org",
+        heading: "Tasks",
+        template: "* TODO %{title}"
+      }
+
+  The `%{title}` placeholder is replaced with user input. Templates
+  are configurable via the extension config.
+
+  ## Capture flow
+
+  1. User triggers capture (SPC X)
+  2. Template selection (if multiple templates)
+  3. User enters title/content
+  4. Content is appended to the target file under the specified heading
+  5. User returns to their previous buffer
+
+  This module provides the pure logic for template rendering and
+  content insertion. The UI flow (capture buffer, prompts) requires
+  Minga's input/picker APIs.
+  """
+
+  defmodule Template do
+    @moduledoc "A capture template definition."
+
+    @enforce_keys [:key, :name, :target, :template]
+    defstruct [:key, :name, :target, :template, heading: nil]
+
+    @type t :: %__MODULE__{
+            key: String.t(),
+            name: String.t(),
+            target: String.t(),
+            template: String.t(),
+            heading: String.t() | nil
+          }
+  end
+
+  @type template :: Template.t()
+
+  @doc """
+  Returns the default capture templates.
+  """
+  @spec default_templates() :: [template()]
+  def default_templates do
+    [
+      %Template{
+        key: "t",
+        name: "TODO",
+        target: "~/org/inbox.org",
+        template: "* TODO %{title}"
+      },
+      %Template{
+        key: "n",
+        name: "Note",
+        target: "~/org/inbox.org",
+        template: "* %{title}\n%{body}"
+      },
+      %Template{
+        key: "j",
+        name: "Journal",
+        target: "~/org/journal.org",
+        heading: "Entries",
+        template: "* %{date} %{title}\n%{body}"
+      }
+    ]
+  end
+
+  @doc """
+  Renders a capture template with the given bindings.
+
+  ## Examples
+
+      iex> template = %MingaOrg.Capture.Template{key: "t", name: "TODO", target: "~/org/inbox.org", template: "* TODO %{title}"}
+      iex> MingaOrg.Capture.render(template, %{title: "Buy milk"})
+      "* TODO Buy milk"
+  """
+  @spec render(template(), map()) :: String.t()
+  def render(%Template{template: tmpl}, bindings) do
+    # Add date binding if not provided
+    bindings = Map.put_new(bindings, :date, Date.utc_today() |> Date.to_iso8601())
+    bindings = Map.put_new(bindings, :body, "")
+    bindings = Map.put_new(bindings, :title, "")
+
+    Enum.reduce(bindings, tmpl, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", value)
+    end)
+    |> String.trim_trailing("\n%{body}")
+    |> String.trim_trailing()
+  end
+
+  @doc """
+  Inserts captured content into a file's text.
+
+  If `heading` is specified, appends under that heading (after its
+  last child). If no heading, appends at the end of the file.
+
+  Returns the updated file content.
+  """
+  @spec insert_into(String.t(), String.t(), String.t() | nil) :: String.t()
+  def insert_into(file_content, captured_text, nil) do
+    # Append at end of file
+    content = String.trim_trailing(file_content)
+
+    if content == "" do
+      captured_text <> "\n"
+    else
+      content <> "\n\n" <> captured_text <> "\n"
+    end
+  end
+
+  def insert_into(file_content, captured_text, heading) do
+    lines = String.split(file_content, "\n")
+
+    case find_heading_and_end(lines, heading) do
+      {:ok, insert_idx} ->
+        {before, after_} = Enum.split(lines, insert_idx)
+        new_lines = before ++ [captured_text] ++ after_
+        Enum.join(new_lines, "\n")
+
+      :not_found ->
+        # Heading not found; append at end
+        insert_into(file_content, captured_text, nil)
+    end
+  end
+
+  @doc """
+  Expands `~` in a file path to the user's home directory.
+  """
+  @spec expand_path(String.t()) :: String.t()
+  def expand_path("~/" <> rest) do
+    Path.join(System.user_home!(), rest)
+  end
+
+  def expand_path(path), do: path
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec find_heading_and_end([String.t()], String.t()) ::
+          {:ok, non_neg_integer()} | :not_found
+  defp find_heading_and_end(lines, target_heading) do
+    target_down = String.downcase(target_heading)
+
+    case find_heading_index(lines, target_down, 0) do
+      {:ok, heading_idx, heading_level} ->
+        # Find where this heading's content ends (next same-or-higher level heading)
+        end_idx = find_section_end(lines, heading_idx + 1, heading_level)
+        {:ok, end_idx}
+
+      :not_found ->
+        :not_found
+    end
+  end
+
+  @spec find_heading_index([String.t()], String.t(), non_neg_integer()) ::
+          {:ok, non_neg_integer(), pos_integer()} | :not_found
+  defp find_heading_index([], _target, _idx), do: :not_found
+
+  defp find_heading_index([line | rest], target, idx) do
+    case Regex.run(~r/^(\*+) (.+)$/, line) do
+      [_match, stars, title] ->
+        if String.downcase(String.trim(title)) == target do
+          {:ok, idx, String.length(stars)}
+        else
+          find_heading_index(rest, target, idx + 1)
+        end
+
+      nil ->
+        find_heading_index(rest, target, idx + 1)
+    end
+  end
+
+  @spec find_section_end([String.t()], non_neg_integer(), pos_integer()) :: non_neg_integer()
+  defp find_section_end(lines, from, level) do
+    lines
+    |> Enum.drop(from)
+    |> Enum.with_index(from)
+    |> Enum.find(fn {line, _idx} ->
+      case Regex.run(~r/^(\*+) /, line) do
+        [_match, stars] -> String.length(stars) <= level
+        nil -> false
+      end
+    end)
+    |> case do
+      {_line, idx} -> idx
+      nil -> length(lines)
+    end
+  end
+end

--- a/test/minga_org/capture_test.exs
+++ b/test/minga_org/capture_test.exs
@@ -1,0 +1,136 @@
+defmodule MingaOrg.CaptureTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Capture
+  alias MingaOrg.Capture.Template
+
+  describe "render/2" do
+    test "renders TODO template" do
+      tmpl = %Template{
+        key: "t",
+        name: "TODO",
+        target: "~/org/inbox.org",
+        template: "* TODO %{title}"
+      }
+
+      assert "* TODO Buy milk" = Capture.render(tmpl, %{title: "Buy milk"})
+    end
+
+    test "renders note template with body" do
+      tmpl = %Template{
+        key: "n",
+        name: "Note",
+        target: "~/org/inbox.org",
+        template: "* %{title}\n%{body}"
+      }
+
+      result = Capture.render(tmpl, %{title: "Meeting", body: "Discussed project X"})
+      assert result == "* Meeting\nDiscussed project X"
+    end
+
+    test "renders template with empty body" do
+      tmpl = %Template{
+        key: "n",
+        name: "Note",
+        target: "~/org/inbox.org",
+        template: "* %{title}\n%{body}"
+      }
+
+      assert "* Quick note" = Capture.render(tmpl, %{title: "Quick note"})
+    end
+
+    test "renders journal template with date" do
+      tmpl = %Template{
+        key: "j",
+        name: "Journal",
+        target: "~/org/journal.org",
+        heading: "Entries",
+        template: "* %{date} %{title}\n%{body}"
+      }
+
+      result = Capture.render(tmpl, %{title: "Today", date: "2026-03-18"})
+      assert result == "* 2026-03-18 Today"
+    end
+
+    test "provides default date if not given" do
+      tmpl = %Template{key: "j", name: "J", target: "f", template: "* %{date} %{title}"}
+      result = Capture.render(tmpl, %{title: "Entry"})
+      # Should contain today's date
+      assert String.contains?(result, "Entry")
+      assert String.match?(result, ~r/\d{4}-\d{2}-\d{2}/)
+    end
+  end
+
+  describe "insert_into/3" do
+    test "appends to empty file" do
+      assert "* TODO Task\n" = Capture.insert_into("", "* TODO Task", nil)
+    end
+
+    test "appends to end of file" do
+      content = "* Heading\nSome text"
+      result = Capture.insert_into(content, "* TODO New", nil)
+      assert result == "* Heading\nSome text\n\n* TODO New\n"
+    end
+
+    test "inserts under specific heading" do
+      content = "* Tasks\n- Old task\n* Notes\nSome notes"
+      result = Capture.insert_into(content, "- New task", "Tasks")
+      lines = String.split(result, "\n")
+      # New task should be between "- Old task" and "* Notes"
+      assert Enum.at(lines, 2) == "- New task"
+    end
+
+    test "falls back to end if heading not found" do
+      content = "* Other\nText"
+      result = Capture.insert_into(content, "* TODO New", "Missing Heading")
+      assert String.contains?(result, "* TODO New")
+    end
+
+    test "inserts at end of deeply nested section" do
+      content = "* H1\n** H2\nBody\n* H3\nOther"
+      result = Capture.insert_into(content, "New line", "H1")
+      lines = String.split(result, "\n")
+      # Should be inserted before * H3 (at index 3)
+      assert Enum.at(lines, 3) == "New line"
+    end
+
+    test "case-insensitive heading match" do
+      content = "* My Tasks\n- item"
+      result = Capture.insert_into(content, "- new", "my tasks")
+      assert String.contains?(result, "- new")
+    end
+  end
+
+  describe "expand_path/1" do
+    test "expands tilde" do
+      result = Capture.expand_path("~/org/inbox.org")
+      refute String.starts_with?(result, "~")
+      assert String.ends_with?(result, "org/inbox.org")
+    end
+
+    test "leaves absolute paths unchanged" do
+      assert "/absolute/path" = Capture.expand_path("/absolute/path")
+    end
+
+    test "leaves relative paths unchanged" do
+      assert "relative/path" = Capture.expand_path("relative/path")
+    end
+  end
+
+  describe "default_templates/0" do
+    test "returns non-empty list" do
+      templates = Capture.default_templates()
+      assert length(templates) >= 2
+    end
+
+    test "includes TODO template" do
+      templates = Capture.default_templates()
+      assert Enum.any?(templates, &(&1.name == "TODO"))
+    end
+
+    test "includes Note template" do
+      templates = Capture.default_templates()
+      assert Enum.any?(templates, &(&1.name == "Note"))
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds org-capture support (#10): template rendering and content insertion.

### Pure logic (`MingaOrg.Capture`)
- Configurable templates with `%{title}`, `%{body}`, `%{date}` placeholders
- `render/2` expands templates with user bindings
- `insert_into/3` appends captured content under a specific heading or at end of file
- Case-insensitive heading matching for target insertion
- `expand_path/1` handles `~` expansion
- 3 default templates: TODO, Note, Journal

### Deferred
- Capture UI flow (`SPC X` trigger, template picker, capture buffer, confirm/abort keybindings) requires Minga's input/picker/buffer creation APIs
- Custom templates via user config file

## Testing
17 new tests. 103 total, 0 failures.

Closes #10