### PR TITLE
feat(table): wire TAB-to-align with insert-mode filetype keybinding (#33)

### DIFF
--- a/lib/minga_org/commands.ex
+++ b/lib/minga_org/commands.ex
@@ -11,6 +11,7 @@ defmodule MingaOrg.Commands do
   alias MingaOrg.Folding
   alias MingaOrg.Heading
   alias MingaOrg.LinkFollow
+  alias MingaOrg.TableCommands
   alias MingaOrg.Todo
 
   @typedoc "A command definition: {name, description, function}."
@@ -34,6 +35,8 @@ defmodule MingaOrg.Commands do
       {:org_fold_toggle, "Toggle fold at heading", &Folding.toggle_at_cursor/1},
       {:org_fold_cycle_global, "Cycle global fold state", &Folding.cycle_global/1},
       {:org_follow_link, "Follow link at cursor", &LinkFollow.follow/1},
+      {:org_table_tab, "Table: next cell", &TableCommands.tab/1},
+      {:org_table_shift_tab, "Table: previous cell", &TableCommands.shift_tab/1},
       {:org_export_html, "Export to HTML", &Export.export_command(&1, "html")},
       {:org_export_markdown, "Export to Markdown", &Export.export_command(&1, "markdown")},
       {:org_export_pdf, "Export to PDF", &Export.export_command(&1, "pdf")}

--- a/lib/minga_org/keybindings.ex
+++ b/lib/minga_org/keybindings.ex
@@ -43,7 +43,11 @@ defmodule MingaOrg.Keybindings do
 
       # Folding
       {:normal, "TAB", :org_fold_toggle, "Toggle heading fold", filetype: :org},
-      {:normal, "S-TAB", :org_fold_cycle_global, "Cycle global folds", filetype: :org}
+      {:normal, "S-TAB", :org_fold_cycle_global, "Cycle global folds", filetype: :org},
+
+      # Table navigation (insert mode)
+      {:insert, "TAB", :org_table_tab, "Table: next cell", filetype: :org},
+      {:insert, "S-TAB", :org_table_shift_tab, "Table: previous cell", filetype: :org}
     ]
   end
 

--- a/lib/minga_org/table_commands.ex
+++ b/lib/minga_org/table_commands.ex
@@ -1,0 +1,234 @@
+defmodule MingaOrg.TableCommands do
+  @moduledoc """
+  Editor commands for org table navigation and alignment.
+
+  Provides TAB and S-TAB handlers for insert-mode table editing:
+  re-align the table and move to the next/previous cell.
+  """
+
+  alias MingaOrg.Buffer
+  alias MingaOrg.Table
+
+  @doc """
+  TAB inside a table: re-align and move to the next cell.
+
+  If the cursor is not inside a table row, returns state unchanged
+  (letting the global insert-mode TAB handle indentation).
+  """
+  @spec tab(map()) :: map()
+  def tab(state) do
+    buf = state.buffers.active
+    {cursor_line, cursor_col} = Buffer.cursor(buf)
+
+    case Buffer.line_at(buf, cursor_line) do
+      {:ok, line} ->
+        if Table.table_line?(line) do
+          align_and_move(buf, cursor_line, cursor_col, :forward)
+          state
+        else
+          state
+        end
+
+      _ ->
+        state
+    end
+  end
+
+  @doc """
+  S-TAB inside a table: re-align and move to the previous cell.
+  """
+  @spec shift_tab(map()) :: map()
+  def shift_tab(state) do
+    buf = state.buffers.active
+    {cursor_line, cursor_col} = Buffer.cursor(buf)
+
+    case Buffer.line_at(buf, cursor_line) do
+      {:ok, line} ->
+        if Table.table_line?(line) do
+          align_and_move(buf, cursor_line, cursor_col, :backward)
+          state
+        else
+          state
+        end
+
+      _ ->
+        state
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec align_and_move(pid(), non_neg_integer(), non_neg_integer(), :forward | :backward) :: :ok
+  defp align_and_move(buf, cursor_line, cursor_col, direction) do
+    {table_start, table_lines} = find_table_block(buf, cursor_line)
+    aligned = Table.align_table(table_lines)
+    table_end = table_start + length(table_lines) - 1
+
+    write_aligned_lines(buf, table_start, table_end, table_lines, aligned)
+
+    # Find the cursor's column index in the original line
+    relative_line = cursor_line - table_start
+    original_line = Enum.at(table_lines, relative_line, "")
+    col_index = current_column_index(original_line, cursor_col)
+
+    # Navigate to the target cell in the aligned table
+    {target_line, target_col} =
+      find_target_cell(aligned, relative_line, col_index, direction)
+
+    Buffer.move_to(buf, {table_start + target_line, target_col})
+  end
+
+  @spec find_table_block(pid(), non_neg_integer()) :: {non_neg_integer(), [String.t()]}
+  defp find_table_block(buf, cursor_line) do
+    total = Buffer.line_count(buf)
+    start_line = scan_table_boundary(buf, cursor_line, -1, 0)
+    end_line = scan_table_boundary(buf, cursor_line, 1, total - 1)
+    lines = Buffer.get_lines(buf, start_line, end_line - start_line + 1)
+    {start_line, lines}
+  end
+
+  @spec scan_table_boundary(pid(), non_neg_integer(), -1 | 1, non_neg_integer()) ::
+          non_neg_integer()
+  defp scan_table_boundary(buf, line, direction, limit) do
+    next = line + direction
+
+    if past_limit?(next, direction, limit) do
+      line
+    else
+      maybe_extend_boundary(buf, line, next, direction, limit)
+    end
+  end
+
+  @spec past_limit?(integer(), -1 | 1, non_neg_integer()) :: boolean()
+  defp past_limit?(next, -1, limit), do: next < limit
+  defp past_limit?(next, 1, limit), do: next > limit
+
+  @spec maybe_extend_boundary(
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          -1 | 1,
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp maybe_extend_boundary(buf, line, next, direction, limit) do
+    with {:ok, text} <- Buffer.line_at(buf, next),
+         true <- Table.table_line?(text) do
+      scan_table_boundary(buf, next, direction, limit)
+    else
+      _ -> line
+    end
+  end
+
+  @spec write_aligned_lines(pid(), non_neg_integer(), non_neg_integer(), [String.t()], [
+          String.t()
+        ]) :: :ok
+  defp write_aligned_lines(buf, table_start, _table_end, original, aligned) do
+    edits =
+      original
+      |> Enum.zip(aligned)
+      |> Enum.with_index()
+      |> Enum.reject(fn {{old, new}, _idx} -> old == new end)
+      |> Enum.map(fn {{old, new}, idx} ->
+        line = table_start + idx
+        old_len = String.length(old)
+        {{line, 0}, {line, old_len}, new}
+      end)
+
+    if edits != [] do
+      Buffer.apply_text_edits(buf, edits)
+    end
+
+    :ok
+  end
+
+  @spec current_column_index(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp current_column_index(line, cursor_col) do
+    case Table.cell_at(line, cursor_col) do
+      {:ok, col_index, _start, _end} -> col_index
+      :not_in_table -> 0
+    end
+  end
+
+  @spec find_target_cell([String.t()], non_neg_integer(), non_neg_integer(), :forward | :backward) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp find_target_cell(lines, current_line, col_index, :forward) do
+    target_col = col_index + 1
+    find_data_cell(lines, current_line, target_col, :forward)
+  end
+
+  defp find_target_cell(lines, current_line, col_index, :backward) do
+    target_col = col_index - 1
+    find_data_cell(lines, current_line, target_col, :backward)
+  end
+
+  @spec find_data_cell([String.t()], non_neg_integer(), integer(), :forward | :backward) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp find_data_cell(lines, line_idx, col_idx, direction) do
+    line = Enum.at(lines, line_idx, "")
+    row = Table.parse_row(line)
+    max_col = row_column_count(row) - 1
+
+    cond do
+      # Valid column in current row
+      col_idx >= 0 and col_idx <= max_col and match?({:data, _}, row) ->
+        cell_start_col(line, col_idx)
+        |> then(&{line_idx, &1})
+
+      # Moved past end: go to first cell of next data row
+      direction == :forward ->
+        next_data_line(lines, line_idx + 1, :forward)
+        |> case do
+          {:ok, next_line} -> {next_line, cell_start_col(Enum.at(lines, next_line), 0)}
+          :none -> {line_idx, cell_start_col(line, max(max_col, 0))}
+        end
+
+      # Moved before start: go to last cell of previous data row
+      direction == :backward ->
+        next_data_line(lines, line_idx - 1, :backward)
+        |> case do
+          {:ok, prev_line} ->
+            prev_row = Table.parse_row(Enum.at(lines, prev_line))
+            prev_max = row_column_count(prev_row) - 1
+            {prev_line, cell_start_col(Enum.at(lines, prev_line), max(prev_max, 0))}
+
+          :none ->
+            {line_idx, cell_start_col(line, 0)}
+        end
+    end
+  end
+
+  @spec next_data_line([String.t()], integer(), :forward | :backward) ::
+          {:ok, non_neg_integer()} | :none
+  defp next_data_line(_lines, idx, _dir) when idx < 0, do: :none
+
+  defp next_data_line(lines, idx, _dir) when idx >= length(lines), do: :none
+
+  defp next_data_line(lines, idx, dir) do
+    case Table.parse_row(Enum.at(lines, idx)) do
+      {:data, _} -> {:ok, idx}
+      _ -> next_data_line(lines, idx + if(dir == :forward, do: 1, else: -1), dir)
+    end
+  end
+
+  @spec row_column_count(Table.row() | :not_table) :: non_neg_integer()
+  defp row_column_count({:data, cells}), do: length(cells)
+  defp row_column_count(_), do: 0
+
+  @spec cell_start_col(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp cell_start_col(line, target_col_index) do
+    # Walk through positions to find the cell_at that matches target_col_index
+    line_len = String.length(line)
+    find_cell_start(line, 0, line_len, target_col_index)
+  end
+
+  @spec find_cell_start(String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp find_cell_start(_line, pos, len, _target) when pos >= len, do: 0
+
+  defp find_cell_start(line, pos, len, target) do
+    case Table.cell_at(line, pos) do
+      {:ok, ^target, start, _end} -> start
+      _ -> find_cell_start(line, pos + 1, len, target)
+    end
+  end
+end

--- a/test/minga_org/commands_test.exs
+++ b/test/minga_org/commands_test.exs
@@ -19,6 +19,8 @@ defmodule MingaOrg.CommandsTest do
       assert :org_fold_toggle in names
       assert :org_fold_cycle_global in names
       assert :org_follow_link in names
+      assert :org_table_tab in names
+      assert :org_table_shift_tab in names
       assert :org_export_html in names
       assert :org_export_markdown in names
       assert :org_export_pdf in names

--- a/test/minga_org/table_commands_test.exs
+++ b/test/minga_org/table_commands_test.exs
@@ -1,0 +1,82 @@
+defmodule MingaOrg.TableCommandsTest do
+  use ExUnit.Case, async: true
+
+  import MingaOrg.TestHelpers
+
+  alias MingaOrg.Buffer.Stub
+  alias MingaOrg.TableCommands
+
+  describe "tab/1" do
+    test "aligns a misaligned table and moves to next cell" do
+      buf =
+        start_buffer!(
+          lines: ["| Name | Age |", "|---+---|", "| Alice | 30 |"],
+          cursor: {2, 3}
+        )
+
+      state = make_state(buf)
+      TableCommands.tab(state)
+
+      lines = Stub.lines(buf)
+      # Table should be aligned (columns padded to equal width)
+      assert Enum.all?(lines, &String.starts_with?(&1, "|"))
+
+      # Cursor should have moved to the next cell (Age column)
+      {_line, col} = Stub.cursor(buf)
+      assert col > 3
+    end
+
+    test "returns state unchanged when not in a table" do
+      buf = start_buffer!(lines: ["Just plain text", "Not a table"], cursor: {0, 5})
+      state = make_state(buf)
+
+      result = TableCommands.tab(state)
+
+      assert result == state
+      # Cursor unchanged
+      assert Stub.cursor(buf) == {0, 5}
+    end
+
+    test "wraps to next data row when at last column" do
+      buf =
+        start_buffer!(
+          lines: ["| A | B |", "| C | D |"],
+          cursor: {0, 6}
+        )
+
+      state = make_state(buf)
+      TableCommands.tab(state)
+
+      {line, _col} = Stub.cursor(buf)
+      # Should have moved to the second row
+      assert line == 1
+    end
+  end
+
+  describe "shift_tab/1" do
+    test "moves to previous cell" do
+      buf =
+        start_buffer!(
+          lines: ["| Name  | Age |", "| Alice | 30  |"],
+          cursor: {1, 10}
+        )
+
+      state = make_state(buf)
+      TableCommands.shift_tab(state)
+
+      {line, col} = Stub.cursor(buf)
+      # Should be in the Name column of the same row
+      assert line == 1
+      assert col < 10
+    end
+
+    test "returns state unchanged when not in a table" do
+      buf = start_buffer!(lines: ["Regular text"], cursor: {0, 3})
+      state = make_state(buf)
+
+      result = TableCommands.shift_tab(state)
+
+      assert result == state
+    end
+  end
+end


### PR DESCRIPTION
## What

Wires the existing table alignment logic (`Table.align_table/1`, `Table.cell_at/2`) to insert-mode TAB/S-TAB keybindings scoped to org files. This was blocked on jsmestad/minga#1057 (insert-mode filetype keybinding dispatch) which has now shipped.

## How it works

TAB inside a table cell:
1. Finds the table block (scans up/down for contiguous table lines)
2. Re-aligns all columns via `Table.align_table/1`
3. Writes only changed lines back (diff-based edits)
4. Moves cursor to the next cell (or first cell of next data row at end of row)

S-TAB does the reverse. Both pass through silently when the cursor isn't in a table.

## Changes

- New `MingaOrg.TableCommands` module with `tab/1` and `shift_tab/1`
- Two insert-mode keybindings: `{:insert, "TAB", :org_table_tab, ..., filetype: :org}`
- Two new commands in `command_definitions`
- 5 integration tests using the buffer stub

```
7 properties, 282 tests, 0 failures
mix credo --strict: found no issues
```

Closes #33