### PR TITLE
feat(export): replace per-format keybindings with format picker (#31)

### DIFF
--- a/lib/minga_org/commands.ex
+++ b/lib/minga_org/commands.ex
@@ -7,7 +7,6 @@ defmodule MingaOrg.Commands do
   """
 
   alias MingaOrg.Checkbox
-  alias MingaOrg.Export
   alias MingaOrg.Folding
   alias MingaOrg.Heading
   alias MingaOrg.LinkFollow
@@ -37,9 +36,8 @@ defmodule MingaOrg.Commands do
       {:org_follow_link, "Follow link at cursor", &LinkFollow.follow/1},
       {:org_table_tab, "Table: next cell", &TableCommands.tab/1},
       {:org_table_shift_tab, "Table: previous cell", &TableCommands.shift_tab/1},
-      {:org_export_html, "Export to HTML", &Export.export_command(&1, "html")},
-      {:org_export_markdown, "Export to Markdown", &Export.export_command(&1, "markdown")},
-      {:org_export_pdf, "Export to PDF", &Export.export_command(&1, "pdf")}
+      {:org_export, "Export org file",
+       fn state -> Minga.Editor.PickerUI.open(state, MingaOrg.ExportPicker) end}
     ]
   end
 

--- a/lib/minga_org/export_picker.ex
+++ b/lib/minga_org/export_picker.ex
@@ -1,0 +1,34 @@
+defmodule MingaOrg.ExportPicker do
+  @moduledoc """
+  Picker source for org export format selection.
+
+  Lists all pandoc output formats and triggers export on selection.
+  Opened via `SPC m e`.
+  """
+
+  @behaviour Minga.Picker.Source
+
+  alias MingaOrg.Export
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Export org file"
+
+  @impl true
+  @spec candidates(term()) :: [Minga.Picker.Item.t()]
+  def candidates(_context) do
+    Enum.map(Export.formats(), fn {format_id, display_name} ->
+      %Minga.Picker.Item{id: format_id, label: display_name, description: format_id}
+    end)
+  end
+
+  @impl true
+  @spec on_select(Minga.Picker.Item.t(), map()) :: map()
+  def on_select(%{id: format}, state) do
+    Export.export_command(state, format)
+  end
+
+  @impl true
+  @spec on_cancel(map()) :: map()
+  def on_cancel(state), do: state
+end

--- a/lib/minga_org/keybindings.ex
+++ b/lib/minga_org/keybindings.ex
@@ -37,9 +37,7 @@ defmodule MingaOrg.Keybindings do
       {:normal, "g x", :org_follow_link, "Follow link", filetype: :org},
 
       # Export
-      {:normal, "SPC m e h", :org_export_html, "Export to HTML", filetype: :org},
-      {:normal, "SPC m e m", :org_export_markdown, "Export to Markdown", filetype: :org},
-      {:normal, "SPC m e p", :org_export_pdf, "Export to PDF", filetype: :org},
+      {:normal, "SPC m e", :org_export, "Export org file", filetype: :org},
 
       # Folding
       {:normal, "TAB", :org_fold_toggle, "Toggle heading fold", filetype: :org},

--- a/test/minga_org/commands_test.exs
+++ b/test/minga_org/commands_test.exs
@@ -21,9 +21,7 @@ defmodule MingaOrg.CommandsTest do
       assert :org_follow_link in names
       assert :org_table_tab in names
       assert :org_table_shift_tab in names
-      assert :org_export_html in names
-      assert :org_export_markdown in names
-      assert :org_export_pdf in names
+      assert :org_export in names
     end
 
     test "every definition is a {atom, string, function} tuple" do

--- a/test/minga_org/export_picker_test.exs
+++ b/test/minga_org/export_picker_test.exs
@@ -1,0 +1,42 @@
+defmodule MingaOrg.ExportPickerTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Export
+  alias MingaOrg.ExportPicker
+
+  describe "candidates/1" do
+    test "returns one candidate per format" do
+      candidates = ExportPicker.candidates(nil)
+      assert length(candidates) == length(Export.formats())
+    end
+
+    test "each candidate has an id matching the pandoc format" do
+      ids = ExportPicker.candidates(nil) |> Enum.map(& &1.id)
+
+      assert "html" in ids
+      assert "pdf" in ids
+      assert "markdown" in ids
+    end
+
+    test "each candidate is a Picker.Item struct" do
+      for item <- ExportPicker.candidates(nil) do
+        assert %Minga.Picker.Item{} = item
+        assert is_binary(item.label)
+        assert is_binary(item.description)
+      end
+    end
+  end
+
+  describe "title/0" do
+    test "returns a non-empty string" do
+      assert is_binary(ExportPicker.title())
+    end
+  end
+
+  describe "on_cancel/1" do
+    test "returns state unchanged" do
+      state = %{some: :state}
+      assert ExportPicker.on_cancel(state) == state
+    end
+  end
+end


### PR DESCRIPTION
## What

Replaces the three per-format export keybindings (`SPC m e h`, `SPC m e m`, `SPC m e p`) with a single `SPC m e` that opens a format picker. The picker lists all 7 pandoc output formats. Selecting one triggers `Export.export_command/2`.

## Changes

- New `MingaOrg.ExportPicker` implementing `Minga.Picker.Source` behaviour
- `SPC m e` replaces `SPC m e h/m/p` (one binding instead of three)
- `:org_export` replaces `:org_export_html/markdown/pdf` (one command instead of three)
- 5 new tests for the picker source

Depends on #34 (config options, for the minga dep scope change).

```
7 properties, 287 tests, 0 failures
```

Closes #31