### PR TITLE
feat(tags): wire tag picker for heading filtering (#30)

### DIFF
--- a/lib/minga_org/commands.ex
+++ b/lib/minga_org/commands.ex
@@ -35,6 +35,8 @@ defmodule MingaOrg.Commands do
       {:org_fold_toggle, "Toggle fold at heading", &Folding.toggle_at_cursor/1},
       {:org_fold_cycle_global, "Cycle global fold state", &Folding.cycle_global/1},
       {:org_follow_link, "Follow link at cursor", &LinkFollow.follow/1},
+      {:org_jump_to_tag, "Jump to tag",
+       fn state -> Minga.Editor.PickerUI.open(state, MingaOrg.TagPicker) end},
       {:org_table_tab, "Table: next cell", &TableCommands.tab/1},
       {:org_table_shift_tab, "Table: previous cell", &TableCommands.shift_tab/1},
       {:org_export_html, "Export to HTML", &Export.export_command(&1, "html")},

--- a/lib/minga_org/keybindings.ex
+++ b/lib/minga_org/keybindings.ex
@@ -36,6 +36,9 @@ defmodule MingaOrg.Keybindings do
       {:normal, "RET", :org_follow_link, "Follow link", filetype: :org},
       {:normal, "g x", :org_follow_link, "Follow link", filetype: :org},
 
+      # Tags
+      {:normal, "SPC m T", :org_jump_to_tag, "Jump to tag", filetype: :org},
+
       # Export
       {:normal, "SPC m e h", :org_export_html, "Export to HTML", filetype: :org},
       {:normal, "SPC m e m", :org_export_markdown, "Export to Markdown", filetype: :org},

--- a/lib/minga_org/tag_picker.ex
+++ b/lib/minga_org/tag_picker.ex
@@ -1,0 +1,66 @@
+defmodule MingaOrg.TagPicker do
+  @moduledoc """
+  Picker source for filtering headings by tag.
+
+  Lists all unique tags in the current org buffer. Selecting a tag
+  jumps the cursor to the first heading that contains it.
+  Opened via `SPC m T`.
+  """
+
+  @behaviour Minga.Picker.Source
+
+  alias MingaOrg.Buffer
+  alias MingaOrg.TagCommands
+  alias MingaOrg.Tags
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Jump to tag"
+
+  @impl true
+  @spec candidates(term()) :: [Minga.Picker.Item.t()]
+  def candidates(%{buffers: %{active: buf}}) do
+    TagCommands.all_tags_in_buffer(buf)
+    |> Enum.map(fn tag ->
+      %Minga.Picker.Item{id: tag, label: ":#{tag}:"}
+    end)
+  end
+
+  def candidates(_), do: []
+
+  @impl true
+  @spec on_select(Minga.Picker.Item.t(), map()) :: map()
+  def on_select(%{id: tag}, state) do
+    buf = state.buffers.active
+    total = Buffer.line_count(buf)
+
+    case find_tagged_heading(buf, tag, 0, total) do
+      {:ok, line} ->
+        Buffer.move_to(buf, {line, 0})
+        state
+
+      :not_found ->
+        state
+    end
+  end
+
+  @impl true
+  @spec on_cancel(map()) :: map()
+  def on_cancel(state), do: state
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec find_tagged_heading(pid(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, non_neg_integer()} | :not_found
+  defp find_tagged_heading(_buf, _tag, line, total) when line >= total, do: :not_found
+
+  defp find_tagged_heading(buf, tag, line, total) do
+    with {:ok, text} <- Buffer.line_at(buf, line),
+         %{tags: tags} <- Tags.parse_heading(text),
+         true <- tag in tags do
+      {:ok, line}
+    else
+      _ -> find_tagged_heading(buf, tag, line + 1, total)
+    end
+  end
+end

--- a/test/minga_org/commands_test.exs
+++ b/test/minga_org/commands_test.exs
@@ -19,6 +19,7 @@ defmodule MingaOrg.CommandsTest do
       assert :org_fold_toggle in names
       assert :org_fold_cycle_global in names
       assert :org_follow_link in names
+      assert :org_jump_to_tag in names
       assert :org_table_tab in names
       assert :org_table_shift_tab in names
       assert :org_export_html in names

--- a/test/minga_org/tag_picker_test.exs
+++ b/test/minga_org/tag_picker_test.exs
@@ -1,0 +1,90 @@
+defmodule MingaOrg.TagPickerTest do
+  use ExUnit.Case, async: true
+
+  import MingaOrg.TestHelpers
+
+  alias MingaOrg.Buffer.Stub
+  alias MingaOrg.TagPicker
+
+  describe "candidates/1" do
+    test "returns unique tags from buffer headings" do
+      buf =
+        start_buffer!(
+          lines: [
+            "* Heading one :work:",
+            "Some body text",
+            "* Heading two :work:urgent:",
+            "* Heading three :personal:"
+          ]
+        )
+
+      state = make_state(buf)
+      candidates = TagPicker.candidates(state)
+      ids = Enum.map(candidates, & &1.id)
+
+      assert "work" in ids
+      assert "urgent" in ids
+      assert "personal" in ids
+    end
+
+    test "returns empty list when no tags exist" do
+      buf = start_buffer!(lines: ["* Plain heading", "Body text"])
+      state = make_state(buf)
+
+      assert TagPicker.candidates(state) == []
+    end
+
+    test "each candidate is a Picker.Item with tag label" do
+      buf = start_buffer!(lines: ["* Task :work:"])
+      state = make_state(buf)
+      [item] = TagPicker.candidates(state)
+
+      assert %Minga.Picker.Item{} = item
+      assert item.id == "work"
+      assert item.label == ":work:"
+    end
+  end
+
+  describe "on_select/2" do
+    test "jumps to first heading with selected tag" do
+      buf =
+        start_buffer!(
+          lines: [
+            "* Intro",
+            "Body",
+            "* Task :work:",
+            "Details",
+            "* Other :personal:"
+          ],
+          cursor: {0, 0}
+        )
+
+      state = make_state(buf)
+      TagPicker.on_select(%{id: "work"}, state)
+
+      assert Stub.cursor(buf) == {2, 0}
+    end
+
+    test "does nothing when tag not found" do
+      buf = start_buffer!(lines: ["* No tags here"], cursor: {0, 0})
+      state = make_state(buf)
+
+      TagPicker.on_select(%{id: "nonexistent"}, state)
+
+      assert Stub.cursor(buf) == {0, 0}
+    end
+  end
+
+  describe "title/0" do
+    test "returns a non-empty string" do
+      assert is_binary(TagPicker.title())
+    end
+  end
+
+  describe "on_cancel/1" do
+    test "returns state unchanged" do
+      state = %{some: :state}
+      assert TagPicker.on_cancel(state) == state
+    end
+  end
+end


### PR DESCRIPTION
## What

`SPC m T` opens a picker listing all unique tags in the current org buffer. Selecting a tag jumps the cursor to the first heading that contains it. Uses `TagCommands.all_tags_in_buffer/1` (already complete) to feed the picker.

## Changes

- New `MingaOrg.TagPicker` implementing `Minga.Picker.Source` behaviour
- New `:org_jump_to_tag` command and `SPC m T` keybinding
- 7 integration tests: candidate generation, tag-based navigation, empty buffer, cancel

Depends on #34 (config options, for the minga dep scope change).

```
7 properties, 289 tests, 0 failures
```

Closes #30