### PR TITLE
feat(capture): wire capture UI with picker + prompt flow (#29)

### DIFF
--- a/lib/minga_org/capture_picker.ex
+++ b/lib/minga_org/capture_picker.ex
@@ -1,0 +1,53 @@
+defmodule MingaOrg.CapturePicker do
+  @moduledoc """
+  Picker source for capture template selection.
+
+  Lists available capture templates. Selecting one opens a title
+  prompt via `MingaOrg.CapturePrompt`.
+  Opened via `SPC X`.
+  """
+
+  @behaviour Minga.Picker.Source
+
+  alias MingaOrg.Capture
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Capture template"
+
+  @impl true
+  @spec candidates(term()) :: [Minga.Picker.Item.t()]
+  def candidates(_context) do
+    templates()
+    |> Enum.map(fn template ->
+      %Minga.Picker.Item{
+        id: template,
+        label: "[#{template.key}] #{template.name}",
+        description: template.target
+      }
+    end)
+  end
+
+  @impl true
+  @spec on_select(Minga.Picker.Item.t(), map()) :: map()
+  def on_select(%{id: template}, state) do
+    Minga.Editor.PromptUI.open(state, MingaOrg.CapturePrompt, context: %{template: template})
+  end
+
+  @impl true
+  @spec on_cancel(map()) :: map()
+  def on_cancel(state), do: state
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec templates() :: [Capture.template()]
+  defp templates do
+    case Minga.Config.Options.get_extension_option(:minga_org, :capture_templates) do
+      nil -> Capture.default_templates()
+      custom -> custom
+    end
+  rescue
+    # Config.Options not available (test env or standalone compilation)
+    _ -> Capture.default_templates()
+  end
+end

--- a/lib/minga_org/capture_prompt.ex
+++ b/lib/minga_org/capture_prompt.ex
@@ -1,0 +1,53 @@
+defmodule MingaOrg.CapturePrompt do
+  @moduledoc """
+  Prompt handler for capture title input.
+
+  Receives the selected template via `state.prompt_ui.context.template`,
+  renders the template with the user's input, and writes the result
+  to the target file.
+  """
+
+  @behaviour Minga.Prompt.Handler
+
+  alias MingaOrg.Capture
+
+  @impl true
+  @spec label() :: String.t()
+  def label, do: "Title: "
+
+  @impl true
+  @spec on_submit(String.t(), map()) :: map()
+  def on_submit(title, state) do
+    template = state.prompt_ui.context.template
+    rendered = Capture.render(template, %{title: title})
+    target_path = Capture.expand_path(template.target)
+
+    write_capture(target_path, rendered, template.heading)
+
+    state
+  end
+
+  @impl true
+  @spec on_cancel(map()) :: map()
+  def on_cancel(state), do: state
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec write_capture(String.t(), String.t(), String.t() | nil) :: :ok | {:error, term()}
+  defp write_capture(path, content, heading) do
+    dir = Path.dirname(path)
+    File.mkdir_p!(dir)
+
+    existing = read_or_empty(path)
+    updated = Capture.insert_into(existing, content, heading)
+    File.write(path, updated)
+  end
+
+  @spec read_or_empty(String.t()) :: String.t()
+  defp read_or_empty(path) do
+    case File.read(path) do
+      {:ok, content} -> content
+      {:error, :enoent} -> ""
+    end
+  end
+end

--- a/lib/minga_org/commands.ex
+++ b/lib/minga_org/commands.ex
@@ -26,6 +26,8 @@ defmodule MingaOrg.Commands do
   @spec command_definitions([String.t()]) :: [command_def()]
   def command_definitions(todo_keywords) do
     [
+      {:org_capture, "Quick capture",
+       fn state -> Minga.Editor.PickerUI.open(state, MingaOrg.CapturePicker) end},
       {:org_cycle_todo, "Cycle TODO keyword", &Todo.cycle(&1, todo_keywords)},
       {:org_toggle_checkbox, "Toggle checkbox", &Checkbox.toggle/1},
       {:org_promote_heading, "Promote heading (decrease level)", &Heading.promote/1},

--- a/lib/minga_org/keybindings.ex
+++ b/lib/minga_org/keybindings.ex
@@ -22,6 +22,9 @@ defmodule MingaOrg.Keybindings do
   @spec binding_definitions() :: [binding_def()]
   def binding_definitions do
     [
+      # SPC X — quick capture (global, not filetype-scoped)
+      {:normal, "SPC X", :org_capture, "Quick capture", []},
+
       # SPC m — local leader (org commands)
       {:normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org},
       {:normal, "SPC m x", :org_toggle_checkbox, "Toggle checkbox", filetype: :org},

--- a/test/minga_org/capture_integration_test.exs
+++ b/test/minga_org/capture_integration_test.exs
@@ -1,0 +1,120 @@
+defmodule MingaOrg.CaptureIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.Capture
+  alias MingaOrg.CapturePicker
+  alias MingaOrg.CapturePrompt
+
+  describe "CapturePicker.candidates/1" do
+    test "returns one candidate per default template" do
+      candidates = CapturePicker.candidates(nil)
+      assert length(candidates) == length(Capture.default_templates())
+    end
+
+    test "each candidate is a Picker.Item with template as id" do
+      for item <- CapturePicker.candidates(nil) do
+        assert %Minga.Picker.Item{} = item
+        assert %Capture.Template{} = item.id
+        assert is_binary(item.label)
+        assert is_binary(item.description)
+      end
+    end
+
+    test "labels show key and name" do
+      [todo | _] = CapturePicker.candidates(nil)
+      assert todo.label =~ "[t]"
+      assert todo.label =~ "TODO"
+    end
+  end
+
+  describe "CapturePicker.title/0" do
+    test "returns a non-empty string" do
+      assert is_binary(CapturePicker.title())
+    end
+  end
+
+  describe "CapturePicker.on_cancel/1" do
+    test "returns state unchanged" do
+      state = %{some: :state}
+      assert CapturePicker.on_cancel(state) == state
+    end
+  end
+
+  describe "CapturePrompt.label/0" do
+    test "returns a non-empty string" do
+      assert is_binary(CapturePrompt.label())
+    end
+  end
+
+  describe "CapturePrompt.on_cancel/1" do
+    test "returns state unchanged" do
+      state = %{some: :state}
+      assert CapturePrompt.on_cancel(state) == state
+    end
+  end
+
+  describe "CapturePrompt.on_submit/2 writes to file" do
+    @tag :tmp_dir
+    test "writes rendered template to target file", %{tmp_dir: tmp_dir} do
+      target = Path.join(tmp_dir, "inbox.org")
+
+      template = %Capture.Template{
+        key: "t",
+        name: "TODO",
+        target: target,
+        template: "* TODO %{title}"
+      }
+
+      state = %{prompt_ui: %{context: %{template: template}}}
+      CapturePrompt.on_submit("Buy milk", state)
+
+      assert File.exists?(target)
+      content = File.read!(target)
+      assert content =~ "* TODO Buy milk"
+    end
+
+    @tag :tmp_dir
+    test "appends under heading when specified", %{tmp_dir: tmp_dir} do
+      target = Path.join(tmp_dir, "inbox.org")
+      File.write!(target, "* Tasks\n\n* Other\n")
+
+      template = %Capture.Template{
+        key: "t",
+        name: "TODO",
+        target: target,
+        template: "* TODO %{title}",
+        heading: "Tasks"
+      }
+
+      state = %{prompt_ui: %{context: %{template: template}}}
+      CapturePrompt.on_submit("Review PR", state)
+
+      content = File.read!(target)
+      lines = String.split(content, "\n")
+      tasks_idx = Enum.find_index(lines, &(&1 == "* Tasks"))
+      other_idx = Enum.find_index(lines, &(&1 == "* Other"))
+      todo_idx = Enum.find_index(lines, &(&1 =~ "TODO Review PR"))
+
+      assert todo_idx > tasks_idx
+      assert todo_idx < other_idx
+    end
+
+    @tag :tmp_dir
+    test "creates target file if it does not exist", %{tmp_dir: tmp_dir} do
+      target = Path.join([tmp_dir, "subdir", "new.org"])
+
+      template = %Capture.Template{
+        key: "n",
+        name: "Note",
+        target: target,
+        template: "* %{title}"
+      }
+
+      state = %{prompt_ui: %{context: %{template: template}}}
+      CapturePrompt.on_submit("New note", state)
+
+      assert File.exists?(target)
+      assert File.read!(target) =~ "* New note"
+    end
+  end
+end

--- a/test/minga_org/commands_test.exs
+++ b/test/minga_org/commands_test.exs
@@ -10,6 +10,7 @@ defmodule MingaOrg.CommandsTest do
       defs = Commands.command_definitions(@default_keywords)
       names = Enum.map(defs, &elem(&1, 0))
 
+      assert :org_capture in names
       assert :org_cycle_todo in names
       assert :org_toggle_checkbox in names
       assert :org_promote_heading in names

--- a/test/minga_org/keybindings_test.exs
+++ b/test/minga_org/keybindings_test.exs
@@ -5,11 +5,22 @@ defmodule MingaOrg.KeybindingsTest do
   alias MingaOrg.Keybindings
 
   describe "binding_definitions/0" do
-    test "every binding has filetype: :org" do
-      for {_mode, _key, _cmd, _desc, opts} <- Keybindings.binding_definitions() do
+    test "filetype-scoped bindings have filetype: :org" do
+      for {_mode, _key, cmd, _desc, opts} <- Keybindings.binding_definitions(),
+          opts != [] do
         assert Keyword.get(opts, :filetype) == :org,
-               "all org bindings must be scoped to filetype: :org"
+               "#{cmd} should be scoped to filetype: :org"
       end
+    end
+
+    test "global bindings have empty opts" do
+      global =
+        Keybindings.binding_definitions()
+        |> Enum.filter(fn {_mode, _key, _cmd, _desc, opts} -> opts == [] end)
+
+      assert length(global) == 1
+      [{_mode, _key, cmd, _desc, _opts}] = global
+      assert cmd == :org_capture
     end
 
     test "every binding is a {atom, string, atom, string, keyword} tuple" do


### PR DESCRIPTION
## What

Wires the complete capture flow: `SPC X` opens a template picker, selecting a template opens a title prompt, submitting the title renders the template and writes it to the target file.

## Flow

1. `SPC X` → opens `CapturePicker` (template list from config or defaults)
2. Select template → opens `CapturePrompt` (title input, template passed via context)
3. Type title, submit → `Capture.render/2` fills `%{title}`, `%{date}` → written to target file
4. Cancel at any stage → clean no-op

## Changes

- `MingaOrg.CapturePicker` implements `Minga.Picker.Source`
- `MingaOrg.CapturePrompt` implements `Minga.Prompt.Handler`
- `:org_capture` command + global `SPC X` keybinding (not filetype-scoped, matching Doom Emacs)
- File I/O: creates target file/directory if missing, appends under heading if specified
- 10 new integration tests (file write, heading insertion, file creation, cancel)
- Original 17 capture unit tests preserved

Depends on #34 (config options).

```
7 properties, 293 tests, 0 failures
```

Closes #29