### PR TITLE
feat(tags): render heading tags as pill badge annotations

### DIFF
--- a/lib/minga_org.ex
+++ b/lib/minga_org.ex
@@ -39,6 +39,10 @@ defmodule MingaOrg do
     default: ["TODO", "DONE"],
     description: "TODO keyword cycle sequence"
 
+  option :tag_colors, :any,
+    default: nil,
+    description: "Map of tag name to hex color for pill annotations (nil uses auto-palette)"
+
   option :capture_templates, :any,
     default: nil,
     description: "Capture template definitions (nil uses built-in defaults)"

--- a/lib/minga_org/advice.ex
+++ b/lib/minga_org/advice.ex
@@ -10,6 +10,7 @@ defmodule MingaOrg.Advice do
   alias MingaOrg.List
   alias MingaOrg.Markup
   alias MingaOrg.Pretty
+  alias MingaOrg.TagAnnotations
 
   @typedoc "An advice definition: {phase, command, function}."
   @type advice_def :: {:around | :after | :before, atom(), function()}
@@ -26,7 +27,8 @@ defmodule MingaOrg.Advice do
     around = [{:around, :insert_newline, &smart_newline/2}]
 
     after_advice =
-      for cmd <- refresh_commands, fun <- [&Markup.refresh/1, &Pretty.refresh/1] do
+      for cmd <- refresh_commands,
+          fun <- [&Markup.refresh/1, &Pretty.refresh/1, &TagAnnotations.refresh/1] do
         {:after, cmd, fun}
       end
 

--- a/lib/minga_org/tag_annotations.ex
+++ b/lib/minga_org/tag_annotations.ex
@@ -1,0 +1,219 @@
+defmodule MingaOrg.TagAnnotations do
+  @moduledoc """
+  Renders org heading tags as pill badge annotations.
+
+  Parses heading lines for tags and replaces the raw `:tag1:tag2:` syntax
+  with colored pill badges using Minga's line annotation API. Each tag
+  becomes a separate `:inline_pill` annotation positioned after the
+  heading text.
+
+  On non-cursor lines, the raw tag text is concealed and pills are shown.
+  On the cursor line, raw syntax is visible for editing (no pills, no conceals).
+
+  All decorations use the `:org_tags` group for bulk clear/refresh.
+
+  ## Color strategy
+
+  Tags get a background color by hashing the tag name into a predefined
+  palette. This gives consistent colors per tag name without configuration.
+  Users can override individual tag colors via the extension config.
+  """
+
+  alias MingaOrg.Buffer
+  alias MingaOrg.Tags
+
+  @group :org_tags
+
+  # Visually distinct pill colors (indigo, emerald, amber, rose, sky, violet, orange, teal).
+  # Foreground is always white for contrast.
+  @default_palette [
+    0x6366F1,
+    0x10B981,
+    0xF59E0B,
+    0xF43F5E,
+    0x0EA5E9,
+    0x8B5CF6,
+    0xF97316,
+    0x14B8A6
+  ]
+
+  @default_fg 0xFFFFFF
+
+  @typedoc "Configuration for tag pill annotations."
+  @type config :: %{
+          palette: [non_neg_integer()],
+          fg: non_neg_integer(),
+          tag_colors: %{String.t() => non_neg_integer()},
+          enabled: boolean()
+        }
+
+  @typedoc "A decoration descriptor for tag annotations."
+  @type descriptor ::
+          {:annotation, non_neg_integer(), String.t(), non_neg_integer(), non_neg_integer()}
+          | {:conceal, non_neg_integer(), non_neg_integer(), non_neg_integer()}
+
+  @doc """
+  Returns the default configuration.
+  """
+  @spec default_config() :: config()
+  def default_config do
+    %{
+      palette: @default_palette,
+      fg: @default_fg,
+      tag_colors: %{},
+      enabled: true
+    }
+  end
+
+  @doc """
+  Refreshes tag pill annotations for the active org buffer.
+
+  State -> state function for use as command advice.
+  """
+  @spec refresh(map()) :: map()
+  def refresh(state) do
+    buf = state.buffers.active
+
+    if Buffer.filetype(buf) == :org do
+      apply_decorations(buf)
+    end
+
+    state
+  end
+
+  @doc """
+  Applies tag pill annotations for all lines in the buffer.
+
+  Fetches all lines in a single call, computes descriptors, and
+  applies them in a batch.
+  """
+  @spec apply_decorations(pid()) :: :ok
+  def apply_decorations(buf) do
+    total = Buffer.line_count(buf)
+    {cursor_line, _col} = Buffer.cursor(buf)
+    lines = Buffer.get_lines(buf, 0, total)
+
+    tag_colors = Minga.Config.Options.get_extension_option(:minga_org, :tag_colors) || %{}
+    config = %{default_config() | tag_colors: tag_colors}
+    descriptors = compute_descriptors(lines, cursor_line, config)
+
+    Buffer.batch_decorations(buf, fn decs ->
+      decs = Minga.Buffer.Decorations.remove_group(decs, @group)
+
+      Enum.reduce(descriptors, decs, fn desc, decs ->
+        apply_descriptor(decs, desc)
+      end)
+    end)
+  end
+
+  @doc """
+  Computes tag annotation descriptors for a list of lines.
+
+  Pure function. Returns a list of annotation and conceal descriptors.
+  The cursor line is excluded (raw syntax visible for editing).
+
+  ## Example
+
+      compute_descriptors(["* Heading :work:urgent:"], 99)
+      #=> [
+      #=>   {:conceal, 0, 9, 23},
+      #=>   {:annotation, 0, "work", bg_color, 0xFFFFFF},
+      #=>   {:annotation, 0, "urgent", bg_color, 0xFFFFFF}
+      #=> ]
+  """
+  @spec compute_descriptors([String.t()], non_neg_integer(), config()) :: [descriptor()]
+  def compute_descriptors(lines, cursor_line, config \\ default_config())
+
+  def compute_descriptors(_lines, _cursor_line, %{enabled: false}), do: []
+
+  def compute_descriptors(lines, cursor_line, config) do
+    lines
+    |> Enum.with_index()
+    |> Enum.reject(fn {_line, line_num} -> line_num == cursor_line end)
+    |> Enum.flat_map(fn {line, line_num} ->
+      descriptors_for_line(line, line_num, config)
+    end)
+  end
+
+  @doc """
+  Returns the background color for a tag name.
+
+  If the tag has an explicit color in the config, that's used.
+  Otherwise, the tag name is hashed into the palette.
+
+  ## Examples
+
+      iex> MingaOrg.TagAnnotations.color_for_tag("work", MingaOrg.TagAnnotations.default_config())
+      0x14B8A6
+  """
+  @spec color_for_tag(String.t(), config()) :: non_neg_integer()
+  def color_for_tag(tag, %{tag_colors: overrides, palette: palette}) do
+    case Map.get(overrides, tag) do
+      nil -> Enum.at(palette, hash_index(tag, length(palette)))
+      color -> color
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec descriptors_for_line(String.t(), non_neg_integer(), config()) :: [descriptor()]
+  defp descriptors_for_line(line, line_num, config) do
+    case Tags.parse_heading(line) do
+      %{raw_tags: nil} ->
+        []
+
+      %{tags: tags, raw_tags: raw_tags} when is_binary(raw_tags) ->
+        conceal = build_conceal(line, line_num, raw_tags)
+        annotations = build_annotations(line_num, tags, config)
+        [conceal | annotations]
+
+      :not_heading ->
+        []
+    end
+  end
+
+  @spec build_conceal(String.t(), non_neg_integer(), String.t()) :: descriptor()
+  defp build_conceal(line, line_num, raw_tags) do
+    line_len = String.length(line)
+    tag_len = String.length(raw_tags)
+    # Conceal the space before tags + the tag text itself
+    start_col = max(line_len - tag_len - 1, 0)
+    {:conceal, line_num, start_col, line_len}
+  end
+
+  @spec build_annotations(non_neg_integer(), [String.t()], config()) :: [descriptor()]
+  defp build_annotations(line_num, tags, config) do
+    Enum.map(tags, fn tag ->
+      bg = color_for_tag(tag, config)
+      {:annotation, line_num, tag, bg, config.fg}
+    end)
+  end
+
+  @spec hash_index(String.t(), pos_integer()) :: non_neg_integer()
+  defp hash_index(tag, palette_size) do
+    <<hash::unsigned-32, _rest::binary>> = :erlang.md5(tag)
+    rem(hash, palette_size)
+  end
+
+  @spec apply_descriptor(struct(), descriptor()) :: struct()
+  defp apply_descriptor(decs, {:conceal, line_num, start_col, end_col}) do
+    {_id, decs} =
+      Minga.Buffer.Decorations.add_conceal(decs, {line_num, start_col}, {line_num, end_col},
+        group: @group
+      )
+
+    decs
+  end
+
+  defp apply_descriptor(decs, {:annotation, line_num, text, bg, fg}) do
+    {_id, decs} =
+      Minga.Buffer.Decorations.add_annotation(decs, line_num, text,
+        kind: :inline_pill,
+        bg: bg,
+        fg: fg,
+        group: @group
+      )
+
+    decs
+  end
+end

--- a/test/minga_org/tag_annotations_test.exs
+++ b/test/minga_org/tag_annotations_test.exs
@@ -1,0 +1,151 @@
+defmodule MingaOrg.TagAnnotationsTest do
+  use ExUnit.Case, async: true
+
+  alias MingaOrg.TagAnnotations
+
+  doctest MingaOrg.TagAnnotations
+
+  describe "compute_descriptors/3" do
+    test "heading with tags produces conceal and annotation descriptors" do
+      lines = ["* Heading :work:urgent:"]
+      descs = TagAnnotations.compute_descriptors(lines, 99)
+
+      assert length(descs) == 3
+
+      # Conceal the " :work:urgent:" portion (space + raw tags)
+      assert {:conceal, 0, start_col, end_col} = Enum.at(descs, 0)
+      assert start_col == 9
+      assert end_col == 23
+
+      # Annotation for each tag
+      assert {:annotation, 0, "work", _bg1, 0xFFFFFF} = Enum.at(descs, 1)
+      assert {:annotation, 0, "urgent", _bg2, 0xFFFFFF} = Enum.at(descs, 2)
+    end
+
+    test "heading without tags produces no descriptors" do
+      lines = ["* Heading without tags"]
+      assert [] = TagAnnotations.compute_descriptors(lines, 99)
+    end
+
+    test "non-heading lines produce no descriptors" do
+      lines = ["Just some body text", "- list item", ""]
+      assert [] = TagAnnotations.compute_descriptors(lines, 99)
+    end
+
+    test "cursor line is excluded" do
+      lines = ["* Heading :work:"]
+      assert [] = TagAnnotations.compute_descriptors(lines, 0)
+    end
+
+    test "disabled config produces no descriptors" do
+      config = %{TagAnnotations.default_config() | enabled: false}
+      lines = ["* Heading :work:"]
+      assert [] = TagAnnotations.compute_descriptors(lines, 99, config)
+    end
+
+    test "multiple headings produce descriptors for each" do
+      lines = [
+        "* Task 1 :work:",
+        "Body text",
+        "** Sub task :review:urgent:"
+      ]
+
+      descs = TagAnnotations.compute_descriptors(lines, 99)
+
+      # Line 0: 1 conceal + 1 annotation = 2
+      # Line 2: 1 conceal + 2 annotations = 3
+      assert length(descs) == 5
+
+      line_0_descs = Enum.filter(descs, fn d -> elem(d, 1) == 0 end)
+      line_2_descs = Enum.filter(descs, fn d -> elem(d, 1) == 2 end)
+
+      assert length(line_0_descs) == 2
+      assert length(line_2_descs) == 3
+    end
+
+    test "single tag produces one conceal and one annotation" do
+      lines = ["* Todo :next:"]
+      descs = TagAnnotations.compute_descriptors(lines, 99)
+
+      assert length(descs) == 2
+      assert {:conceal, 0, _, _} = Enum.at(descs, 0)
+      assert {:annotation, 0, "next", _, _} = Enum.at(descs, 1)
+    end
+
+    test "conceal covers the space before tags" do
+      # "** AB :x:" has title "AB" at positions 0-4 ("** AB"), then " :x:" at 5-9
+      lines = ["** AB :x:"]
+      [{:conceal, 0, start_col, end_col} | _] = TagAnnotations.compute_descriptors(lines, 99)
+
+      # The raw_tags is ":x:", which is 3 chars. The line is 9 chars.
+      # start_col = 9 - 3 - 1 = 5 (the space before the colon)
+      assert start_col == 5
+      assert end_col == 9
+    end
+
+    test "deeply nested heading works" do
+      lines = ["**** Deep :nested:tags:here:"]
+      descs = TagAnnotations.compute_descriptors(lines, 99)
+
+      # 1 conceal + 3 annotations
+      assert length(descs) == 4
+
+      annotations = Enum.filter(descs, fn d -> elem(d, 0) == :annotation end)
+      tag_names = Enum.map(annotations, fn {:annotation, _, name, _, _} -> name end)
+      assert tag_names == ["nested", "tags", "here"]
+    end
+  end
+
+  describe "color_for_tag/2" do
+    test "returns a color from the palette" do
+      config = TagAnnotations.default_config()
+      color = TagAnnotations.color_for_tag("work", config)
+      assert color in config.palette
+    end
+
+    test "same tag always gets the same color" do
+      config = TagAnnotations.default_config()
+
+      assert TagAnnotations.color_for_tag("work", config) ==
+               TagAnnotations.color_for_tag("work", config)
+    end
+
+    test "different tags get deterministic colors from the palette" do
+      config = TagAnnotations.default_config()
+      # MD5 hash picks a palette index; verify known values
+      assert TagAnnotations.color_for_tag("work", config) == 0x14B8A6
+      assert TagAnnotations.color_for_tag("urgent", config) == 0xF97316
+      assert TagAnnotations.color_for_tag("personal", config) == 0x6366F1
+
+      # Different tags get different colors (these three hash to distinct indices)
+      colors = [
+        TagAnnotations.color_for_tag("work", config),
+        TagAnnotations.color_for_tag("urgent", config),
+        TagAnnotations.color_for_tag("personal", config)
+      ]
+
+      assert length(Enum.uniq(colors)) == 3
+    end
+
+    test "explicit tag_colors override the palette" do
+      config = %{TagAnnotations.default_config() | tag_colors: %{"work" => 0xFF0000}}
+      assert TagAnnotations.color_for_tag("work", config) == 0xFF0000
+    end
+
+    test "non-overridden tags still use the palette" do
+      config = %{TagAnnotations.default_config() | tag_colors: %{"work" => 0xFF0000}}
+      color = TagAnnotations.color_for_tag("personal", config)
+      assert color in config.palette
+    end
+  end
+
+  describe "default_config/0" do
+    test "returns expected defaults" do
+      config = TagAnnotations.default_config()
+      assert config.enabled == true
+      assert config.fg == 0xFFFFFF
+      assert length(config.palette) == 8
+      assert config.tag_colors == %{}
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Org heading tags (`:work:`, `:urgent:`) now render as colored pill badges instead of raw colon-delimited text, using the line annotation API from jsmestad/minga#1132.

Closes #35

## Context

Ticket #35 adds visual tag rendering as part of the [org-mode epic (#1)](https://github.com/jsmestad/minga-org/issues/1). With jsmestad/minga#1132 merged (line annotation rendering for GUI and TUI), the extension can now display tags as native pill badges after heading text.

## Changes

- **New `MingaOrg.TagAnnotations` module** following the same refresh/compute/apply pattern as `Pretty` and `Markup`. Parses heading lines via `Tags.parse_heading/1`, conceals raw tag syntax on non-cursor lines, and adds `:inline_pill` annotations for each tag.
- **Hash-based color palette**: tag names are MD5-hashed into an 8-color palette for consistent, visually distinct colors without configuration. Users can override specific tag colors via the new `tag_colors` extension option.
- **Cursor line exclusion**: raw `:tag:` syntax stays visible on the cursor line for editing. Moving away conceals the raw text and shows pills.
- **Advice wiring**: `TagAnnotations.refresh/1` registered as `:after` advice on cursor movement and edit commands, same as `Markup.refresh` and `Pretty.refresh`.
- **Extension config**: added `option :tag_colors` for explicit `%{"work" => 0xFF0000}` overrides. Read at runtime via `Minga.Config.Options.get_extension_option/2`.

## Verification

```bash
mix format --check-formatted   # clean
mix credo --strict              # 0 issues
mix compile --warnings-as-errors # clean
mix dialyzer                    # 0 errors
mix test                        # 325 tests + 1 doctest + 7 properties, 0 failures
```

Focused test run:
```bash
mix test test/minga_org/tag_annotations_test.exs
# 15 tests + 1 doctest, 0 failures
```

## Acceptance Criteria Addressed

- Heading tags render as pill annotations (one pill per tag) after the heading text ✅
- Each tag gets a distinct background color (hashed from tag name, configurable overrides) ✅
- Annotations refresh when the buffer content changes (advice on editing commands) ✅
- The cursor line shows raw tag syntax, non-cursor lines show pills ✅
- Tags concealed by Markup/LinkMarkup do not double-render (separate group, distinct syntax) ✅
- The annotation group `:org_tags` is used for batch clear/refresh ✅
- Tag annotations work alongside existing pretty bullets and inline markup decorations ✅